### PR TITLE
Use the file icon from the theme

### DIFF
--- a/images/bookmark-explorer-dark.svg
+++ b/images/bookmark-explorer-dark.svg
@@ -1,1 +1,0 @@
-<?xml version="1.0" ?><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><defs><style>.cls-1{fill:none;stroke:#fff;stroke-linejoin:round;stroke-width:2px;}</style></defs><title/><g data-name="473-Bookmark" id="_473-Bookmark"><polygon class="cls-1" points="6 1 6 23 6 31 16 23 26 31 26 23 26 1 6 1"/></g></svg>

--- a/images/bookmark-explorer-light.svg
+++ b/images/bookmark-explorer-light.svg
@@ -1,1 +1,0 @@
-<?xml version="1.0" ?><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><defs><style>.cls-1{fill:none;stroke:#000;stroke-linejoin:round;stroke-width:2px;}</style></defs><title/><g data-name="473-Bookmark" id="_473-Bookmark"><polygon class="cls-1" points="6 1 6 23 6 31 16 23 26 31 26 23 26 1 6 1"/></g></svg>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.18.0"
+        "vscode": "^1.22.0"
     },
     "categories": [
         "Other"

--- a/src/BookmarkProvider.ts
+++ b/src/BookmarkProvider.ts
@@ -273,12 +273,9 @@ class BookmarkNode extends vscode.TreeItem {
     super(label, collapsibleState);
 
     if (kind === BookmarkNodeKind.NODE_FILE) {
-      if (hasIcons) {
-        this.iconPath = {
-          light: context.asAbsolutePath("images/bookmark-explorer-light.svg"),
-          dark: context.asAbsolutePath("images/bookmark-explorer-dark.svg")
-        }; 
-      }
+      this.resourceUri = vscode.Uri.file(bookmark.fsPath);
+      this.iconPath = vscode.ThemeIcon.File;
+      this.id = bookmark.fsPath;
       this.contextValue = "BookmarkNodeFile";
     } else {
       this.iconPath = {

--- a/src/BookmarkProvider.ts
+++ b/src/BookmarkProvider.ts
@@ -9,12 +9,11 @@ export enum BookmarkNodeKind { NODE_FILE, NODE_BOOKMARK };
 
 export interface BookmarkPreview {
   file: string;
-  line: number;    
-  preview: string; 
+  line: number;
+  preview: string;
 };
 
 let context: vscode.ExtensionContext;
-let hasIcons: boolean = vscode.workspace.getConfiguration("workbench").get("iconTheme", "") !== null;
 
 export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode> {
 
@@ -43,12 +42,12 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode> {
       if (this.tree.length === 0) {
         this._onDidChangeTreeData.fire();
         return;
-      } 
-      
+      }
+
       // has bookmarks - find it
       for (let bn of this.tree) {
         if (bn.bookmark === bkm.bookmark) {
-          
+
           bn.books.push({
             file: bn.books[0].file,
             line: bkm.line,
@@ -83,8 +82,8 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode> {
       if (this.tree.length === 0) {
         this._onDidChangeTreeData.fire();
         return;
-      } 
-      
+      }
+
       // has bookmarks - find it
       for (let bn of this.tree) {
         if (bn.bookmark === bkm.bookmark) {
@@ -109,25 +108,25 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode> {
     });
 
     bookmarks.onDidUpdateBookmark( bkm => {
-      
+
       // no bookmark in this file
       if (this.tree.length === 0) {
         this._onDidChangeTreeData.fire();
         return;
-      } 
-        
+      }
+
       // has bookmarks - find it
       for (let bn of this.tree) {
         if (bn.bookmark === bkm.bookmark) {
-          
+
           bn.books[bkm.index].line = bkm.line;
           bn.books[bkm.index].preview = bkm.line.toString() + ': ' + bkm.preview;
-          
+
           this._onDidChangeTreeData.fire(bn);
           return;
         }
       }
-  
+
       // not found - new file
       this._onDidChangeTreeData.fire();
     });
@@ -240,7 +239,7 @@ function removeBasePathFrom(aPath: string): string {
   if (!vscode.workspace.workspaceFolders) {
     return aPath;
   }
-        
+
   let inWorkspace: vscode.WorkspaceFolder;
   for (const wf of vscode.workspace.workspaceFolders) {
       if (aPath.indexOf(wf.uri.fsPath) === 0) {
@@ -263,6 +262,7 @@ function removeBasePathFrom(aPath: string): string {
 class BookmarkNode extends vscode.TreeItem {
 
   constructor(
+
     public readonly label: string,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly kind: BookmarkNodeKind,
@@ -281,7 +281,7 @@ class BookmarkNode extends vscode.TreeItem {
       this.iconPath = {
         light: context.asAbsolutePath("images/bookmark.svg"),
         dark: context.asAbsolutePath("images/bookmark.svg")
-      }; 
+      };
       this.contextValue = "BookmarkNodeBookmark";
     }
   }


### PR DESCRIPTION
The icon for files in the treeview is now the one specified by the theme (same as the explorer view)

![2018-05-10 23_31_15- extension development host - colorstrings fs - coloredprintf - visual studio c](https://user-images.githubusercontent.com/131878/39895789-d1fedff6-54ab-11e8-8d22-794b69b243af.png)
