### PR TITLE
Implement configuration to control navigation wrap around

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,11 @@
                     "default": false,
                     "description": "Allow navigation look for bookmarks in all files in the project, instead of only the current"
                 },
+                "bookmarks.wrapNavigation": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Allow navigation to wrap around at the first and last bookmarks in scope (current file or all files)"
+                },
                 "bookmarks.treeview.visible": {
                     "type": "boolean",
                     "default": true,

--- a/src/Bookmark.ts
+++ b/src/Bookmark.ts
@@ -5,6 +5,8 @@ import fs = require("fs");
 
 export const NO_BOOKMARKS = -1;
 export const NO_MORE_BOOKMARKS = -2;
+export const NO_BOOKMARKS_BEFORE = -3;
+export const NO_BOOKMARKS_AFTER = -4;
 
 export const JUMP_FORWARD = 1;
 export const JUMP_BACKWARD = -1;
@@ -81,6 +83,8 @@ export class BookmarkedFile implements File {
                 }
             }
 
+            const wrapNavigation: boolean = vscode.workspace.getConfiguration("bookmarks").get("wrapNavigation");
+
             let nextBookmark: vscode.Position;
 
             if (direction === JUMP_FORWARD) {
@@ -94,6 +98,9 @@ export class BookmarkedFile implements File {
                 if (typeof nextBookmark === "undefined") {
                     if (navigateThroughAllFiles) {
                         resolve(NO_MORE_BOOKMARKS);
+                        return;
+                    } else if (!wrapNavigation) {
+                        resolve(NO_BOOKMARKS_AFTER);
                         return;
                     } else {
                         resolve(new vscode.Position(this.bookmarks[ 0 ].line, this.bookmarks[ 0 ].column));
@@ -114,6 +121,9 @@ export class BookmarkedFile implements File {
                 if (typeof nextBookmark === "undefined") {
                     if (navigateThroughAllFiles) {
                         resolve(NO_MORE_BOOKMARKS);
+                        return;
+                    } else if (!wrapNavigation) {
+                        resolve(NO_BOOKMARKS_BEFORE);
                         return;
                     } else {
                         resolve(new vscode.Position(this.bookmarks[ this.bookmarks.length - 1 ].line, this.bookmarks[ this.bookmarks.length - 1 ].column));


### PR DESCRIPTION
Hello,

Thought I'd implement a new configuration option to control navigation wrap around behaviour.

The behaviour of this new option, `wrapNavigation`, depends on the existing `navigateThroughAllFiles` option. I've made the former active by default, which preserves the existing behaviour of the extension out of the box.

To clarify a perhaps non-obvious combination: with `wrapNavigation` off and `navigateThroughAllFiles` on, you can still jump between files. However, once you reach the first or last bookmark across all files, it stops you from jumping back around.