### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,11 @@
                     "when": "editorTextFocus && config.bookmarks.showCommandsInContextMenu"
                 },
                 {
+                    "command": "bookmarks.toggleLabeled",
+                    "group": "bookmarks",
+                    "when": "editorTextFocus && config.bookmarks.showCommandsInContextMenu"
+                },
+                {
                     "command": "bookmarks.jumpToNext",
                     "group": "bookmarks@1",
                     "when": "editorTextFocus && config.bookmarks.showCommandsInContextMenu"


### PR DESCRIPTION
Return recently missing `BookMarks: Toggle Labeled` command to the editor context menu.

Previous...
![boomarks-previous](https://user-images.githubusercontent.com/1332009/97004488-0c5fff80-1535-11eb-8ab3-2a3afefdbd20.png)
Now...
![boomarks-now](https://user-images.githubusercontent.com/1332009/97004564-24378380-1535-11eb-8c71-2392113865ec.png)
