### PR TITLE
switch to onStartupFinished 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "11.4.0",
     "publisher": "alefragnani",
     "engines": {
-        "vscode": "^1.45.0"
+        "vscode": "^1.46.0"
     },
     "categories": [
         "Other"
@@ -30,7 +30,7 @@
         "url": "https://github.com/alefragnani/vscode-bookmarks/issues"
     },
     "activationEvents": [
-        "*",
+        "onStartupFinished",
         "onView:bookmarksExplorer"
     ],
     "main": "./dist/extension",


### PR DESCRIPTION
from 1.46 onwards `onStartupFinished` can be used instead of `*`
https://github.com/microsoft/vscode-docs/blob/vnext/release-notes/v1_46.md#onstartupfinished-activation-event
https://code.visualstudio.com/api/references/activation-events#onStartupFinished

_To ensure a great end user experience, please use `*` activation event in your extension only when no other activation events combination works in your use-case. `onStartupFinished` is similar to the `*` activation event, but it will not slow down VS Code startup._

This change can help with VSCode startup time.