### PR TITLE
add extensionKind entry in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
         "onStartupFinished",
         "onView:bookmarksExplorer"
     ],
+    "extensionKind": [
+        "ui"
+    ],
     "main": "./dist/extension",
     "contributes": {
         "viewsContainers": {


### PR DESCRIPTION
By default, extensions are treated as "workspace" extensions and need to be installed where the workspace lives. That means in the case of remote workspaces on the remote server.

By explicitly marking this extension as a UI extension, vcode will install the extension on the client side when working with remote workspaces.

See https://code.visualstudio.com/api/advanced-topics/remote-extensions#architecture-and-extension-kinds