### PR TITLE
Add option to disable "No more bookmarks" notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -367,10 +367,10 @@
                     "default": false,
                     "description": "%bookmarks.configuration.useWorkaroundForFormatters.description%"
                 },
-                "bookmarks.showNotifications": {
+                "bookmarks.showNoMoreBoomarksWarning": {
                   "type": "boolean",
                   "default": true,
-                  "description": "%bookmarks.configuration.showNotifications.description%"
+                  "description": "%bookmarks.configuration.showNoMoreBoomarksWarning.description%"
                 },
                 "bookmarks.showCommandsInContextMenu": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -367,6 +367,11 @@
                     "default": false,
                     "description": "%bookmarks.configuration.useWorkaroundForFormatters.description%"
                 },
+                "bookmarks.showNotifications": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "%bookmarks.configuration.showNotifications.description%"
+                },
                 "bookmarks.showCommandsInContextMenu": {
                     "type": "boolean",
                     "default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -39,6 +39,7 @@
     "bookmarks.configuration.navigateThroughAllFiles.description": "Allow navigation look for bookmarks in all files in the project, instead of only the current",
     "bookmarks.configuration.wrapNavigation.description": "Allow navigation to wrap around at the first and last bookmarks in scope (current file or all files)",
     "bookmarks.configuration.useWorkaroundForFormatters.description": "Use a workaround for formatters like Prettier, which does not notify on document changes and messes Bookmark's Sticky behavior",
+    "bookmarks.configuration.showNotifications.description": "Specifies whether a notification will be shown when attempting to navigate between bookmarks when no more exist.",
     "bookmarks.configuration.showCommandsInContextMenu.description": "Specifies whether Bookmarks commands are displayed on the context menu",
     "bookmarks.configuration.sidebar.expanded.description": "Specifies wheher the Side Bar show be displayed expanded",
     "bookmarks.configuration.multicursor.toggleMode.description": "Specifies how multi cursor handles already bookmarked lines",

--- a/package.nls.json
+++ b/package.nls.json
@@ -39,7 +39,7 @@
     "bookmarks.configuration.navigateThroughAllFiles.description": "Allow navigation look for bookmarks in all files in the project, instead of only the current",
     "bookmarks.configuration.wrapNavigation.description": "Allow navigation to wrap around at the first and last bookmarks in scope (current file or all files)",
     "bookmarks.configuration.useWorkaroundForFormatters.description": "Use a workaround for formatters like Prettier, which does not notify on document changes and messes Bookmark's Sticky behavior",
-    "bookmarks.configuration.showNotifications.description": "Specifies whether a notification will be shown when attempting to navigate between bookmarks when no more exist.",
+    "bookmarks.configuration.showNoMoreBoomarksWarning.description": "Specifies whether a notification will be shown when attempting to navigate between bookmarks when no more exist.",
     "bookmarks.configuration.showCommandsInContextMenu.description": "Specifies whether Bookmarks commands are displayed on the context menu",
     "bookmarks.configuration.sidebar.expanded.description": "Specifies wheher the Side Bar show be displayed expanded",
     "bookmarks.configuration.multicursor.toggleMode.description": "Specifies how multi cursor handles already bookmarked lines",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -620,7 +620,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     function checkBookmarks(result: number | vscode.Position): boolean {
         if (result === NO_BOOKMARKS_BEFORE || result === NO_BOOKMARKS_AFTER) {
-            if (vscode.workspace.getConfiguration("bookmarks").get("showNotifications", true)) {
+            if (vscode.workspace.getConfiguration("bookmarks").get("showNoMoreBoomarksWarning", true)) {
                 vscode.window.showInformationMessage("No more bookmarks");
             }
             return false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -620,7 +620,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
     function checkBookmarks(result: number | vscode.Position): boolean {
         if (result === NO_BOOKMARKS_BEFORE || result === NO_BOOKMARKS_AFTER) {
-            vscode.window.showInformationMessage("No more bookmarks");
+            if (vscode.workspace.getConfiguration("bookmarks").get("showNotifications", true)) {
+                vscode.window.showInformationMessage("No more bookmarks");
+            }
             return false;
         }
         return true;


### PR DESCRIPTION
Particularly when the `wrapNavigation` and `navigateThroughAllFiles` options are disabled, the "No more bookmarks" notification can come up very frequently, and can become distracting.

This adds a configuration option to disable that notification (defaulting to the existing behaviour).

Unfortunately I couldn't build the extension due to the submodule issue, but hopefully it's a simple enough change.

Thanks!
