### PR TITLE
Fix Gutter Icon color settings for WSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -435,13 +435,11 @@
                     "type": "string",
                     "default": "#157EFB",
                     "description": "%bookmarks.configuration.gutterIconFillColor.description%",
-                    "scope": "machine"
                 },
                 "bookmarks.gutterIconBorderColor": {
                     "type": "string",
                     "default": "#157EFB",
                     "description": "%bookmarks.configuration.gutterIconBorderColor.description%",
-                    "scope": "machine"
                 },
                 "bookmarks.backgroundLineColor": {
                     "type": "string",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55322556/224518212-90b6f997-4113-4bed-a229-ff97ffcebdc4.png)

When using WSL the setting for gutter icon is ignored.

Does it even need to have scope? Removed and works, `window` or `application` seem applicable too.