### PR TITLE
Refine extension settings query

### DIFF
--- a/src/commands/openSettings.ts
+++ b/src/commands/openSettings.ts
@@ -8,6 +8,6 @@ import { Container } from "../../vscode-bookmarks-core/src/container";
 
 export function registerOpenSettings() {
     Container.context.subscriptions.push(commands.registerCommand("bookmarks.openSettings", async () => {
-        commands.executeCommand("workbench.action.openSettings", "bookmarks");
+        commands.executeCommand("workbench.action.openSettings", "@ext:alefragnani.bookmarks");
     }));
 }


### PR DESCRIPTION
The `Open settings` action opens the settings with the query `bookmarks`. However, the result contains several items that are unrelated to the extension, such as `Default Folding Range Provider` and `Default Formatter`.

<img width="580" alt="image" src="https://github.com/alefragnani/vscode-bookmarks/assets/116561995/8caa0fa2-3175-4856-aca2-b69f1da57a76">

I have adjusted the query to show only the settings of this extension.