### PR TITLE
Add "notes"  to bookmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,11 @@
                 "icon": "$(edit)"
             },
             {
+                "command": "_bookmarks.editBookmarkNote",
+                "title": "Edit Note",
+                "icon": "$(note)"
+            },
+            {
                 "command": "_bookmarks.addBookmarkAtLine#gutter",
                 "title": "%bookmarks.commands.addBookmarkAtLine#gutter.title%"
             },
@@ -422,6 +427,11 @@
                     "command": "_bookmarks.editLabel",
                     "when": "view == bookmarksExplorer && viewItem == BookmarkNodeBookmark",
                     "group": "bookmark@1"
+                },
+                {
+                    "command": "_bookmarks.editBookmarkNote",
+                    "when": "view == bookmarksExplorer && viewItem == BookmarkNodeBookmark",
+                    "group": "bookmark@3"
                 },
                 {
                     "command": "_bookmarks.editLabel",

--- a/src/commands/editBookmarkNote.ts
+++ b/src/commands/editBookmarkNote.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import { Bookmark } from "../core/bookmark";
+import { Controller } from "../core/controller";
+import { File } from "../core/file";
+import { indexOfBookmark } from "../core/operations";
+
+
+export function registerEditBookmarkNote(controllers: Controller[]) {
+    vscode.commands.registerCommand("_bookmarks.editBookmarkNote", async (node) => {
+        // 1. Identify Controller and Bookmark
+        // The command might be triggered from:
+        // a) Sidebar Context Menu (node is BookmarkNode)
+        // b) Editor Context Menu / Command Palette (needs active editor resolution)
+
+        let controller: Controller;
+        let file: File;
+        let bookmarkIndex: number;
+        let bookmark: Bookmark;
+
+
+        if (node && node.command && node.command.arguments) {
+            const [filePath, line, col, uri] = node.command.arguments;
+            const uriObj = uri;
+
+            // Find controller
+            for (const c of controllers) {
+                if (c.fromUri(uriObj)) {
+                    controller = c;
+                    break;
+                }
+            }
+
+            if (!controller) {
+                return;
+            }
+
+            file = controller.fromUri(uriObj);
+            bookmarkIndex = indexOfBookmark(file, line - 1);
+        } else {
+            const editor = vscode.window.activeTextEditor;
+            if (editor) {
+                for (const c of controllers) {
+                    if (c.fromUri(editor.document.uri)) {
+                        controller = c;
+                        break;
+                    }
+                }
+
+                if (controller) {
+                    file = controller.fromUri(editor.document.uri);
+                    bookmarkIndex = indexOfBookmark(file, editor.selection.active.line);
+                }
+            }
+        }
+
+        if (!controller || !file || bookmarkIndex === -1) {
+            vscode.window.showInformationMessage("No bookmark found at current line.");
+            return;
+        }
+
+        bookmark = file.bookmarks[bookmarkIndex];
+
+        // Construct URI
+        // Using JSON stringify for query to handle spaces/special chars safely
+        const query = JSON.stringify({
+            path: file.path,
+            line: bookmark.line
+        });
+
+        const uri = vscode.Uri.parse(`vscode-bookmarks-note:/Note.md?${query}`);
+
+        const doc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(doc, { preview: false });
+    });
+}

--- a/src/core/bookmark.ts
+++ b/src/core/bookmark.ts
@@ -9,8 +9,10 @@ export interface Bookmark {
     line: number;
     column: number;
     label?: string;
+    note?: string;
 }
 
 export interface BookmarkQuickPickItem extends QuickPickItem {
     uri: Uri;
+    note?: string;
 }

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -19,6 +19,7 @@ interface BookmarkAdded {
     column: number;
     linePreview?: string;
     label?: string;
+    note?: string;
     uri: Uri;
 }
 
@@ -33,7 +34,8 @@ interface BookmarkUpdated {
     line: number;
     column?: number;
     linePreview?: string;
-    label?: string
+    label?: string;
+    note?: string;
 }
 
 enum ToggleMode {
@@ -394,6 +396,18 @@ export class Controller {
                 label: b.bookmarks[ index ].label
             });
         }
+    }
+
+    public updateBookmarkNote(book: File, index: number, note: string): void {
+        book.bookmarks[index].note = note;
+        // Re-use update event or create a new one? Reuse seems fine as it triggers refresh
+        this.onDidUpdateBookmarkEmitter.fire({
+            file: book,
+            index,
+            line: book.bookmarks[index].line + 1,
+            label: book.bookmarks[index].label,
+            note: note
+        });
     }
 
     public hasAnyBookmark(): boolean {

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -73,7 +73,7 @@ export function nextBookmark(file: File, currentPosition: Position, direction: D
                     resolve(NO_BOOKMARKS_BEFORE);
                     return;
                 } else {
-                    resolve(new Position(file.bookmarks[ file.bookmarks.length - 1 ].line, file.bookmarks[ file.bookmarks.length - 1 ].column));
+                    resolve(new Position(file.bookmarks[file.bookmarks.length - 1 ].line, file.bookmarks[ file.bookmarks.length - 1 ].column));
                     return;
                 }
             } else {
@@ -136,15 +136,17 @@ export function listBookmarks(file: File, workspaceFolder: WorkspaceFolder) {
                                 bookmarkColumn.toString() + ")",
                             label: lineText,
                             detail: file.path,
-                            uri: uriDocBookmark
+                            uri: uriDocBookmark,
+                            note: file.bookmarks[index].note
                         });
                     } else {
                         items.push({
                             description: "(Ln " + bookmarkLine.toString() + ", Col " +
                                 bookmarkColumn.toString() + ")",
-                            label: codicons.tag + " " + file.bookmarks[ index ].label,
+                            label: codicons.tag + " " + file.bookmarks[index].label,
                             detail: file.path,
-                            uri: uriDocBookmark
+                            uri: uriDocBookmark,
+                            note: file.bookmarks[index].note
                         });
                     }
                 } else {
@@ -154,7 +156,7 @@ export function listBookmarks(file: File, workspaceFolder: WorkspaceFolder) {
             if (invalids.length > 0) {
                 let idxInvalid: number;
                 for (let indexI = 0; indexI < invalids.length; indexI++) {
-                    idxInvalid = file.bookmarks.indexOf(<Bookmark>{ line: invalids[ indexI ] - 1 });
+                    idxInvalid = file.bookmarks.indexOf(<Bookmark>{ line: invalids[ indexI ]- 1 });
                     file.bookmarks.splice(idxInvalid, 1);
                 }
             }

--- a/src/providers/bookmarkNoteProvider.ts
+++ b/src/providers/bookmarkNoteProvider.ts
@@ -1,0 +1,88 @@
+import * as vscode from 'vscode';
+import { Controller } from '../core/controller';
+import { indexOfBookmark } from '../core/operations';
+import { saveBookmarks } from '../storage/workspaceState';
+
+export class BookmarkNoteProvider implements vscode.FileSystemProvider {
+
+    constructor(private controllers: Controller[]) { }
+
+    // Events
+    private _onDidChangeFile = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+    readonly onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]> = this._onDidChangeFile.event;
+
+    watch(uri: vscode.Uri, options: { recursive: boolean; excludes: string[]; }): vscode.Disposable {
+        // We don't really support watching yet, but we need to implement the method
+        return new vscode.Disposable(() => { });
+    }
+
+    stat(uri: vscode.Uri): vscode.FileStat {
+        return {
+            type: vscode.FileType.File,
+            ctime: Date.now(),
+            mtime: Date.now(),
+            size: 0 // Size is dynamic, we could calculate it but 0 usually works for virtual
+        };
+    }
+
+    readDirectory(uri: vscode.Uri): [string, vscode.FileType][] {
+        return []; // We don't support directories
+    }
+
+    createDirectory(uri: vscode.Uri): void {
+        throw vscode.FileSystemError.NoPermissions();
+    }
+
+    async readFile(uri: vscode.Uri): Promise<Uint8Array> {
+        const { controller, file, index } = this.resolveUri(uri);
+        const note = file.bookmarks[index].note || "";
+        const encoder = new TextEncoder();
+        return encoder.encode(note);
+    }
+
+    async writeFile(uri: vscode.Uri, content: Uint8Array, options: { create: boolean; overwrite: boolean; }): Promise<void> {
+        const { controller, file, index } = this.resolveUri(uri);
+        const decoder = new TextDecoder();
+        const note = decoder.decode(content);
+
+        controller.updateBookmarkNote(file, index, note);
+        await saveBookmarks(controller);
+
+        // Notify change
+        this._onDidChangeFile.fire([{ type: vscode.FileChangeType.Changed, uri }]);
+    }
+
+    delete(uri: vscode.Uri, options: { recursive: boolean; }): void {
+        throw vscode.FileSystemError.NoPermissions();
+    }
+
+    rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { overwrite: boolean; }): void {
+        throw vscode.FileSystemError.NoPermissions();
+    }
+
+    private resolveUri(uri: vscode.Uri): { controller: Controller, file: any, index: number } {
+        const query = JSON.parse(uri.query);
+        const filePath = query.path;
+        const line = query.line;
+
+        const controller = this.controllers.find(c => {
+            return c.files.some(f => f.path === filePath);
+        });
+
+        if (!controller) {
+            throw vscode.FileSystemError.FileNotFound();
+        }
+
+        const file = controller.files.find(f => f.path === filePath);
+        if (!file) {
+            throw vscode.FileSystemError.FileNotFound();
+        }
+
+        const index = indexOfBookmark(file, line);
+        if (index === -1) {
+            throw vscode.FileSystemError.FileNotFound();
+        }
+
+        return { controller, file, index };
+    }
+}

--- a/src/sidebar/bookmarkNode.ts
+++ b/src/sidebar/bookmarkNode.ts
@@ -3,7 +3,7 @@
 *  Licensed under the GPLv3 License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { Command, TreeItem, TreeItemCollapsibleState, Uri, workspace } from "vscode";
+import { Command, MarkdownString, TreeItem, TreeItemCollapsibleState, Uri, workspace } from "vscode";
 import { DEFAULT_GUTTER_ICON_BORDER_COLOR, DEFAULT_GUTTER_ICON_FILL_COLOR } from "../core/constants";
 import { File } from "../core/file";
 import { BookmarkNodeKind } from "./nodes";
@@ -14,6 +14,7 @@ export interface BookmarkPreview {
     column: number;
     preview: string;
     uri: Uri;
+    note?: string;
 }
 
 export class BookmarkNode extends TreeItem {
@@ -25,11 +26,17 @@ export class BookmarkNode extends TreeItem {
         public readonly kind: BookmarkNodeKind,
         public readonly bookmark: File,
         public readonly books?: BookmarkPreview[],
-        public readonly command?: Command
+        public readonly command?: Command,
+        public readonly note?: string
     ) {
         super(label, collapsibleState);
 
         this.description = relativePath;
+        if (note) {
+            this.tooltip = new MarkdownString(note);
+        } else {
+            this.tooltip = undefined; // Default behavior
+        }
         const iconFillColor = workspace.getConfiguration("bookmarks").get("gutterIconFillColor", DEFAULT_GUTTER_ICON_FILL_COLOR);
         const iconBorderColor = workspace.getConfiguration("bookmarks").get("gutterIconBorderColor", DEFAULT_GUTTER_ICON_BORDER_COLOR);
         const iconPath = Uri.parse(

--- a/src/sidebar/bookmarkProvider.ts
+++ b/src/sidebar/bookmarkProvider.ts
@@ -76,7 +76,8 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode | 
                                 line: bkm.line,
                                 column: bkm.column,
                                 preview: "\u270E " + bkm.label,
-                                uri: bkm.uri
+                                uri: bkm.uri,
+                                note: bkm.note
                             });
                         }
 
@@ -158,6 +159,7 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode | 
                         } else {
                             bn.books[ bkm.index ].preview = "\u270E " + bkm.label;
                         }
+                        bn.books[ bkm.index ].note = bkm.note;
 
                         this._onDidChangeTreeData.fire(bn);
                         return;
@@ -235,7 +237,8 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode | 
                                                             line: point.line,
                                                             column: point.column,
                                                             preview: elementInside.label.replace(codicons.tag, "\u270E"),
-                                                            uri: elementInside.uri
+                                                            uri: elementInside.uri,
+                                                            note: elementInside.note
                                                         }
                                                     );
                                                 }
@@ -268,7 +271,7 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode | 
                             command: "_bookmarks.jumpTo",
                             title: "",
                             arguments: [ bbb.file, bbb.line, bbb.column, bbb.uri ],
-                        }));
+                        }, bbb.note));
                     }
 
                     resolve(ll);
@@ -331,7 +334,8 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode | 
                                                             line: point.line,
                                                             column: point.column,
                                                             preview: elementInside.label.replace(codicons.tag, "\u270E"),
-                                                            uri: elementInside.uri
+                                                            uri: elementInside.uri,
+                                                            note: elementInside.note
                                                         }
                                                     );
                                                 }
@@ -357,7 +361,7 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode | 
                                         command: "_bookmarks.jumpTo",
                                         title: "",
                                         arguments: [ bbb.file, bbb.line, bbb.column, bbb.uri ],
-                                    }));
+                                    }, bbb.note));
                                 }
                             });
                             resolve(bookmarkNodes);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
 	},
 	"exclude": [
 		"node_modules",
-        ".vscode-test"
+		".vscode-test"
 	]
 }


### PR DESCRIPTION
# Feature: Markdown Notes for Bookmarks

## Summary
This PR introduces the ability to attach Markdown notes to bookmarks. Users can now write detailed notes for each bookmark using a full VS Code editor, and view them via gutter hover tooltips or the sidebar.

## Key Changes
- **Detailed Notes**: Bookmarks now support a `note` property for storing Markdown text.
- **Full Editor Experience**: Implemented a `vscode.FileSystemProvider` (`vscode-bookmarks-note`) to allow editing notes in a standard VS Code editor window. This enables multiline editing, formatting, and standard editor features.
- **Enhanced Decorations**: 
    - Hovering over a bookmark in the gutter now displays the note content.
    - Added an "Edit" action link directly in the hover tooltip to quickly open the note editor.
- **Sidebar Integration**: Updated the sidebar to support/display bookmark notes.

## Technical Details
- **New Command**: `_bookmarks.editBookmarkNote` handles opening the virtual document for a specific bookmark.
- **Virtual File System**: [BookmarkNoteProvider](file:///c:/Users/WingD/Desktop/git/open%20source/vscode-bookmarks/src/providers/bookmarkNoteProvider.ts#6-89) implements `FileSystemProvider` to handle [readFile](file:///c:/Users/WingD/Desktop/git/open%20source/vscode-bookmarks/src/providers/bookmarkNoteProvider.ts#36-42) and [writeFile](file:///c:/Users/WingD/Desktop/git/open%20source/vscode-bookmarks/src/providers/bookmarkNoteProvider.ts#43-54) operations for the `vscode-bookmarks-note` scheme. 
    - Notes are decoded/encoded to/from the bookmark storage on the fly.
    - Saving the virtual document automatically updates the bookmark note in the global storage.
- **Storage**: Updated [Bookmark](file:///c:/Users/WingD/Desktop/git/open%20source/vscode-bookmarks/src/providers/bookmarkNoteProvider.ts#6-89) interface and controller logic to persist notes.

## Screenshots
Editing a note:
<img width="320" height="149" alt="image" src="https://github.com/user-attachments/assets/f42cc022-4841-4bd2-8dcb-ae54810a9d61" />
Opens a tmp md file:
<img width="248" height="194" alt="image" src="https://github.com/user-attachments/assets/5ae5b899-a439-4bdc-b19d-e4935d8e384f" />
Hover to show comment:
<img width="291" height="195" alt="image" src="https://github.com/user-attachments/assets/dfe016da-0636-4efa-9647-7a979df22b44" />


