### PR TITLE
Release v14.1.1 - Fix kudos attribution in release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [14.1.1] - 2026-04-07
+### Fixed
+- Fix kudos attribution in v14.1.0 release notes (issue [#882](https://github.com/alefragnani/vscode-bookmarks/issues/882))
+
 ## [14.1.0] - 2026-04-06
 ### Added
 - Ability to export bookmarks (issue [#172](https://github.com/alefragnani/vscode-bookmarks/issues/172))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "Bookmarks",
-    "version": "14.1.0",
+    "version": "14.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "Bookmarks",
-            "version": "14.1.0",
+            "version": "14.1.1",
             "license": "GPL-3.0",
             "dependencies": {
                 "os-browserify": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "Bookmarks",
     "displayName": "Bookmarks",
     "description": "Mark lines and jump to them",
-    "version": "14.1.0",
+    "version": "14.1.1",
     "publisher": "alefragnani",
     "engines": {
         "vscode": "^1.78.0"

--- a/src/whats-new/contentProvider.ts
+++ b/src/whats-new/contentProvider.ts
@@ -20,6 +20,16 @@ export class BookmarksContentProvider implements ContentProvider {
     public provideChangeLog(): ChangeLogItem[] {
         const changeLog: ChangeLogItem[] = [];
 
+        changeLog.push({ kind: ChangeLogKind.VERSION, detail: { releaseNumber: "14.1.1", releaseDate: "March 2026 - Recovery 1" } });
+        changeLog.push({
+            kind: ChangeLogKind.FIXED,
+            detail: {
+                message: "Fix kudos attribution in v14.1.0 release notes",
+                id: 882,
+                kind: IssueKind.Issue,
+            }
+        });
+
         changeLog.push({ kind: ChangeLogKind.VERSION, detail: { releaseNumber: "14.1.0", releaseDate: "March 2026" } });
         changeLog.push({
             kind: ChangeLogKind.NEW,


### PR DESCRIPTION
## What's new in v14.1.1

This is a patch release that corrects an attribution error in the v14.1.0 release notes.

### Fixed

- **Fix kudos attribution in v14.1.0 release notes** ([#882](https://github.com/alefragnani/vscode-bookmarks/issues/882)) — The What's New content provider and CHANGELOG were updated to properly credit the contributor who requested the export bookmarks feature in the previous release.

### Changes

- `CHANGELOG.md` — Added v14.1.1 entry with the fix note
- `src/whats-new/contentProvider.ts` — Added v14.1.1 version block with the corrected attribution entry
- `package.json` — Bumped version from `14.1.0` to `14.1.1`