### PR TITLE
[FEATURE] Bookmark Groups

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -30,5 +30,11 @@
     "A local copy of bookmarks was found in the project. Do you want to load?":"A local copy of bookmarks was found in the project. Do you want to load?",
     "The project's file was last modified at {0}":"The project's file was last modified at {0}",
     "One of the projects in the workspace has a bookmarks file. The most recent was modified at {0}":"One of the projects in the workspace has a bookmarks file. The most recent was modified at {0}",
-    "Clear":"Clear"
+    "Clear":"Clear",
+    "Active Bookmark Group: {0}. Click to switch.":"Active Bookmark Group: {0}. Click to switch.",
+    "Active bookmark group set to {0}":"Active bookmark group set to {0}",
+    "Bookmark moved to group {0}":"Bookmark moved to group {0}",
+    "Select active bookmark group":"Select active bookmark group",
+    "(active)":"(active)",
+    "(empty)":"(empty)"
 }

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -33,7 +33,6 @@
     "Clear":"Clear",
     "Active Bookmark Group: {0}. Click to switch.":"Active Bookmark Group: {0}. Click to switch.",
     "Active bookmark group set to {0}":"Active bookmark group set to {0}",
-    "Bookmark moved to group {0}":"Bookmark moved to group {0}",
     "Select active bookmark group":"Select active bookmark group",
     "(active)":"(active)",
     "(empty)":"(empty)"

--- a/package.json
+++ b/package.json
@@ -255,56 +255,6 @@
                 "command": "bookmarks.switchActiveGroup",
                 "title": "%bookmarks.commands.switchActiveGroup.title%",
                 "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup0",
-                "title": "%bookmarks.commands.toggleGroup0.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup1",
-                "title": "%bookmarks.commands.toggleGroup1.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup2",
-                "title": "%bookmarks.commands.toggleGroup2.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup3",
-                "title": "%bookmarks.commands.toggleGroup3.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup4",
-                "title": "%bookmarks.commands.toggleGroup4.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup5",
-                "title": "%bookmarks.commands.toggleGroup5.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup6",
-                "title": "%bookmarks.commands.toggleGroup6.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup7",
-                "title": "%bookmarks.commands.toggleGroup7.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup8",
-                "title": "%bookmarks.commands.toggleGroup8.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
-            },
-            {
-                "command": "bookmarks.toggleGroup9",
-                "title": "%bookmarks.commands.toggleGroup9.title%",
-                "category": "%bookmarks.commands.category.bookmarks%"
             }
         ],
         "menus": {
@@ -845,66 +795,6 @@
                 "command": "bookmarks.expandSelectionToPrevious",
                 "key": "shift+alt+j",
                 "mac": "shift+alt+j",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup0",
-                "key": "ctrl+alt+0",
-                "mac": "cmd+alt+0",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup1",
-                "key": "ctrl+alt+1",
-                "mac": "cmd+alt+1",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup2",
-                "key": "ctrl+alt+2",
-                "mac": "cmd+alt+2",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup3",
-                "key": "ctrl+alt+3",
-                "mac": "cmd+alt+3",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup4",
-                "key": "ctrl+alt+4",
-                "mac": "cmd+alt+4",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup5",
-                "key": "ctrl+alt+5",
-                "mac": "cmd+alt+5",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup6",
-                "key": "ctrl+alt+6",
-                "mac": "cmd+alt+6",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup7",
-                "key": "ctrl+alt+7",
-                "mac": "cmd+alt+7",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup8",
-                "key": "ctrl+alt+8",
-                "mac": "cmd+alt+8",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "bookmarks.toggleGroup9",
-                "key": "ctrl+alt+9",
-                "mac": "cmd+alt+9",
                 "when": "editorTextFocus"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -250,6 +250,61 @@
                 "command": "bookmarks.export",
                 "title": "%bookmarks.commands.export.title%",
                 "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.switchActiveGroup",
+                "title": "%bookmarks.commands.switchActiveGroup.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup0",
+                "title": "%bookmarks.commands.toggleGroup0.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup1",
+                "title": "%bookmarks.commands.toggleGroup1.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup2",
+                "title": "%bookmarks.commands.toggleGroup2.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup3",
+                "title": "%bookmarks.commands.toggleGroup3.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup4",
+                "title": "%bookmarks.commands.toggleGroup4.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup5",
+                "title": "%bookmarks.commands.toggleGroup5.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup6",
+                "title": "%bookmarks.commands.toggleGroup6.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup7",
+                "title": "%bookmarks.commands.toggleGroup7.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup8",
+                "title": "%bookmarks.commands.toggleGroup8.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
+            },
+            {
+                "command": "bookmarks.toggleGroup9",
+                "title": "%bookmarks.commands.toggleGroup9.title%",
+                "category": "%bookmarks.commands.category.bookmarks%"
             }
         ],
         "menus": {
@@ -719,6 +774,39 @@
                     "maximum": 900,
                     "default": 400,
                     "description": "%bookmarks.configuration.label.inline.fontWeight.description%"
+                },
+                "bookmarks.groups": {
+                    "type": "array",
+                    "description": "%bookmarks.configuration.groups.description%",
+                    "maxItems": 10,
+                    "default": [
+                        { "id": 0, "name": "Default", "color": "#157EFB", "borderColor": "#157EFB" },
+                        { "id": 1, "name": "Group 1", "color": "#FF6B6B", "borderColor": "#FF6B6B" },
+                        { "id": 2, "name": "Group 2", "color": "#51CF66", "borderColor": "#51CF66" },
+                        { "id": 3, "name": "Group 3", "color": "#FCC419", "borderColor": "#FCC419" },
+                        { "id": 4, "name": "Group 4", "color": "#CC5DE8", "borderColor": "#CC5DE8" },
+                        { "id": 5, "name": "Group 5", "color": "#22B8CF", "borderColor": "#22B8CF" },
+                        { "id": 6, "name": "Group 6", "color": "#FF922B", "borderColor": "#FF922B" },
+                        { "id": 7, "name": "Group 7", "color": "#845EF7", "borderColor": "#845EF7" },
+                        { "id": 8, "name": "Group 8", "color": "#868E96", "borderColor": "#868E96" },
+                        { "id": 9, "name": "Group 9", "color": "#20C997", "borderColor": "#20C997" }
+                    ],
+                    "items": {
+                        "type": "object",
+                        "required": ["id", "name", "color"],
+                        "properties": {
+                            "id": { "type": "integer", "minimum": 0, "maximum": 9 },
+                            "name": { "type": "string", "minLength": 1 },
+                            "color": { "type": "string", "format": "color" },
+                            "borderColor": { "type": "string", "format": "color" }
+                        }
+                    },
+                    "scope": "application"
+                },
+                "bookmarks.groups.hideEmpty": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%bookmarks.configuration.groups.hideEmpty.description%"
                 }
             }
         },
@@ -757,6 +845,66 @@
                 "command": "bookmarks.expandSelectionToPrevious",
                 "key": "shift+alt+j",
                 "mac": "shift+alt+j",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup0",
+                "key": "ctrl+alt+0",
+                "mac": "cmd+alt+0",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup1",
+                "key": "ctrl+alt+1",
+                "mac": "cmd+alt+1",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup2",
+                "key": "ctrl+alt+2",
+                "mac": "cmd+alt+2",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup3",
+                "key": "ctrl+alt+3",
+                "mac": "cmd+alt+3",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup4",
+                "key": "ctrl+alt+4",
+                "mac": "cmd+alt+4",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup5",
+                "key": "ctrl+alt+5",
+                "mac": "cmd+alt+5",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup6",
+                "key": "ctrl+alt+6",
+                "mac": "cmd+alt+6",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup7",
+                "key": "ctrl+alt+7",
+                "mac": "cmd+alt+7",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup8",
+                "key": "ctrl+alt+8",
+                "mac": "cmd+alt+8",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "bookmarks.toggleGroup9",
+                "key": "ctrl+alt+9",
+                "mac": "cmd+alt+9",
                 "when": "editorTextFocus"
             }
         ],

--- a/package.nls.json
+++ b/package.nls.json
@@ -110,5 +110,18 @@
     "bookmarks.walkthroughs.workingWithRemotes.title": "Working with Remotes",
     "bookmarks.walkthroughs.workingWithRemotes.description": "The extension support [Remote Development](https://code.visualstudio.com/docs/remote/remote-overview) scenarios. Even installed locally, you can use Bookmarks in WSL, Containers, SSH and Codespaces.",
     "bookmarks.walkthroughs.customizingAppearance.title": "Customizing Appearance",
-    "bookmarks.walkthroughs.customizingAppearance.description": "Customize how Bookmarks are presented, its icon, line and overview ruler\n[Open Settings - Gutter Icon](command:workbench.action.openSettings?%5B%22bookmarks.gutterIcon%22%5D)\n[Open Settings - Line](command:workbench.action.openSettingsJson?%5B%22workbench.colorCustomizations%22%5D)"
+    "bookmarks.walkthroughs.customizingAppearance.description": "Customize how Bookmarks are presented, its icon, line and overview ruler\n[Open Settings - Gutter Icon](command:workbench.action.openSettings?%5B%22bookmarks.gutterIcon%22%5D)\n[Open Settings - Line](command:workbench.action.openSettingsJson?%5B%22workbench.colorCustomizations%22%5D)",
+    "bookmarks.commands.switchActiveGroup.title": "Switch Active Group",
+    "bookmarks.commands.toggleGroup0.title": "Toggle Default Group / Set Active Group 0",
+    "bookmarks.commands.toggleGroup1.title": "Toggle Group 1 / Set Active Group 1",
+    "bookmarks.commands.toggleGroup2.title": "Toggle Group 2 / Set Active Group 2",
+    "bookmarks.commands.toggleGroup3.title": "Toggle Group 3 / Set Active Group 3",
+    "bookmarks.commands.toggleGroup4.title": "Toggle Group 4 / Set Active Group 4",
+    "bookmarks.commands.toggleGroup5.title": "Toggle Group 5 / Set Active Group 5",
+    "bookmarks.commands.toggleGroup6.title": "Toggle Group 6 / Set Active Group 6",
+    "bookmarks.commands.toggleGroup7.title": "Toggle Group 7 / Set Active Group 7",
+    "bookmarks.commands.toggleGroup8.title": "Toggle Group 8 / Set Active Group 8",
+    "bookmarks.commands.toggleGroup9.title": "Toggle Group 9 / Set Active Group 9",
+    "bookmarks.configuration.groups.description": "Define the 10 bookmark groups with name and color. Each entry's `id` must be 0-9 (0 is the default group); missing entries fall back to defaults.",
+    "bookmarks.configuration.groups.hideEmpty.description": "Hide empty groups in the side bar."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -112,16 +112,6 @@
     "bookmarks.walkthroughs.customizingAppearance.title": "Customizing Appearance",
     "bookmarks.walkthroughs.customizingAppearance.description": "Customize how Bookmarks are presented, its icon, line and overview ruler\n[Open Settings - Gutter Icon](command:workbench.action.openSettings?%5B%22bookmarks.gutterIcon%22%5D)\n[Open Settings - Line](command:workbench.action.openSettingsJson?%5B%22workbench.colorCustomizations%22%5D)",
     "bookmarks.commands.switchActiveGroup.title": "Switch Active Group",
-    "bookmarks.commands.toggleGroup0.title": "Toggle Default Group / Set Active Group 0",
-    "bookmarks.commands.toggleGroup1.title": "Toggle Group 1 / Set Active Group 1",
-    "bookmarks.commands.toggleGroup2.title": "Toggle Group 2 / Set Active Group 2",
-    "bookmarks.commands.toggleGroup3.title": "Toggle Group 3 / Set Active Group 3",
-    "bookmarks.commands.toggleGroup4.title": "Toggle Group 4 / Set Active Group 4",
-    "bookmarks.commands.toggleGroup5.title": "Toggle Group 5 / Set Active Group 5",
-    "bookmarks.commands.toggleGroup6.title": "Toggle Group 6 / Set Active Group 6",
-    "bookmarks.commands.toggleGroup7.title": "Toggle Group 7 / Set Active Group 7",
-    "bookmarks.commands.toggleGroup8.title": "Toggle Group 8 / Set Active Group 8",
-    "bookmarks.commands.toggleGroup9.title": "Toggle Group 9 / Set Active Group 9",
     "bookmarks.configuration.groups.description": "Define the 10 bookmark groups with name and color. Each entry's `id` must be 0-9 (0 is the default group); missing entries fall back to defaults.",
     "bookmarks.configuration.groups.hideEmpty.description": "Hide empty groups in the side bar."
 }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -8,6 +8,8 @@ import { Container } from "../core/container";
 import { Controller } from "../core/controller";
 import { getRelativePath, uriExists, uriWith } from "../utils/fs";
 import { getLinePreview } from "../core/operations";
+import { DEFAULT_GROUP_ID } from "../core/constants";
+import { getGroup } from "../core/groups";
 
 interface BookmarkExportItem {
     file: string;
@@ -15,6 +17,8 @@ interface BookmarkExportItem {
     column: number;
     label: string;
     content: string;
+    group: string;
+    groupColor: string;
 }
 
 function escapeForMarkdown(text: string): string {
@@ -70,12 +74,15 @@ async function collectBookmarks(controllers: Controller[]): Promise<BookmarkExpo
                     displayPath = getRelativePath(controller.workspaceFolder.uri.fsPath, file.path);
                 }
 
+                const group = getGroup(bookmark.groupId ?? DEFAULT_GROUP_ID);
                 bookmarkItems.push({
                     file: displayPath,
                     line: bookmark.line + 1, // Convert to 1-based line numbers
                     column: bookmark.column + 1, // Convert to 1-based column numbers
                     label: bookmark.label || "",
-                    content: content
+                    content: content,
+                    group: group.name,
+                    groupColor: group.color
                 });
             }
         }
@@ -115,7 +122,9 @@ function formatBookmarks(bookmarks: BookmarkExportItem[], pattern: string): stri
             "$line": bookmark.line.toString(),
             "$column": bookmark.column.toString(),
             "$label": isDefaultTableFormat ? escapeForMarkdown(bookmark.label) : bookmark.label,
-            "$content": isDefaultTableFormat ? escapeForMarkdown(bookmark.content) : bookmark.content
+            "$content": isDefaultTableFormat ? escapeForMarkdown(bookmark.content) : bookmark.content,
+            "$group": isDefaultTableFormat ? escapeForMarkdown(bookmark.group) : bookmark.group,
+            "$groupColor": bookmark.groupColor
         };
 
         let line = pattern;

--- a/src/core/bookmark.ts
+++ b/src/core/bookmark.ts
@@ -9,6 +9,7 @@ export interface Bookmark {
     line: number;
     column: number;
     label?: string;
+    groupId: number;
 }
 
 export interface BookmarkQuickPickItem extends QuickPickItem {

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -29,3 +29,32 @@ export const WORKSPACE_ROOTPATH  = "$ROOTPATH$";
 
 export const DEFAULT_GUTTER_ICON_FILL_COLOR = "#157EFB";
 export const DEFAULT_GUTTER_ICON_BORDER_COLOR = "#157EFB";
+
+export const MAX_GROUPS = 10;
+export const DEFAULT_GROUP_ID = 0;
+
+export const DEFAULT_GROUP_COLORS: readonly string[] = [
+    "#157EFB",
+    "#FF6B6B",
+    "#51CF66",
+    "#FCC419",
+    "#CC5DE8",
+    "#22B8CF",
+    "#FF922B",
+    "#845EF7",
+    "#868E96",
+    "#20C997"
+];
+
+export const DEFAULT_GROUP_NAMES: readonly string[] = [
+    "Default",
+    "Group 1",
+    "Group 2",
+    "Group 3",
+    "Group 4",
+    "Group 5",
+    "Group 6",
+    "Group 7",
+    "Group 8",
+    "Group 9"
+];

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -7,11 +7,24 @@ import os = require("os");
 import path = require("path");
 import * as vscode from "vscode";
 import { Uri, WorkspaceFolder } from "vscode";
-import { Directions, NO_BOOKMARKS_AFTER, NO_BOOKMARKS_BEFORE, NO_MORE_BOOKMARKS, UNTITLED_SCHEME } from "./constants";
+import { Bookmark } from "./bookmark";
+import { DEFAULT_GROUP_ID, Directions, MAX_GROUPS, NO_BOOKMARKS_AFTER, NO_BOOKMARKS_BEFORE, NO_MORE_BOOKMARKS, UNTITLED_SCHEME } from "./constants";
 import { createFile, File } from "./file";
 import { getFileUri, getRelativePath, uriExists } from "../utils/fs";
 import { clear, getLinePreview, indexOfBookmark } from "./operations";
 import { updateLinesWithBookmarkContext } from "../gutter/editorLineNumberContext";
+import { getActiveGroupId } from "./groupState";
+
+function normalizeGroupId(value: unknown): number {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return DEFAULT_GROUP_ID;
+    }
+    const id = Math.floor(value);
+    if (id < 0 || id >= MAX_GROUPS) {
+        return DEFAULT_GROUP_ID;
+    }
+    return id;
+}
 
 interface BookmarkAdded {
     file: File;
@@ -33,7 +46,8 @@ interface BookmarkUpdated {
     line: number;
     column?: number;
     linePreview?: string;
-    label?: string
+    label?: string;
+    groupId?: number;
 }
 
 enum ToggleMode {
@@ -256,7 +270,7 @@ export class Controller {
         }
     }
 
-    public async toggle(selections: readonly vscode.Selection[], label?: string, book?: File): Promise<boolean> {
+    public async toggle(selections: readonly vscode.Selection[], label?: string, book?: File, groupId?: number): Promise<boolean> {
         const b: File = book ? book : this.activeFile;
         const toggleMode = vscode.workspace.getConfiguration("bookmarks").get<string>("multicursor.toggleMode", "allLinesAtOnce");
         let toggleState: ToggleState | undefined;
@@ -284,7 +298,7 @@ export class Controller {
                     if (index > -1) {
                         this.removeBookmark(index, selection.active.line, b);
                     } else { // toggle on -> add
-                        await this.addBookmark(selection.active, label, b);
+                        await this.addBookmark(selection.active, label, b, groupId);
                         added = true;
                     }
                 } else {
@@ -295,7 +309,7 @@ export class Controller {
                         this.removeBookmark(index, selection.active.line, b);
                     } else {
                         if (index === -1) {
-                            await this.addBookmark(selection.active, label, b);
+                            await this.addBookmark(selection.active, label, b, groupId);
                         }
                         added = true;
                     }
@@ -306,13 +320,15 @@ export class Controller {
     }
 
 
-    public async addBookmark(position: vscode.Position, label?: string, book?: File): Promise<void> {
+    public async addBookmark(position: vscode.Position, label?: string, book?: File, groupId?: number): Promise<void> {
         const b: File = book ? book : this.activeFile;
+        const resolvedGroupId = normalizeGroupId(groupId ?? getActiveGroupId(this.workspaceFolder));
         if (!label) {
             b.bookmarks.push({
                 line: position.line,
                 column: position.character,
-                label: ""
+                label: "",
+                groupId: resolvedGroupId
             });
             let linePreview: string;
             if (book) {
@@ -332,7 +348,8 @@ export class Controller {
             b.bookmarks.push({
                 line: position.line,
                 column: position.character,
-                label
+                label,
+                groupId: resolvedGroupId
             });
             this.onDidAddBookmarkEmitter.fire({
                 file: b,
@@ -342,6 +359,24 @@ export class Controller {
                 uri: this.getFileUri(b)
             });
         }
+    }
+
+    public changeGroup(index: number, newGroupId: number, book?: File): void {
+        const b: File = book ? book : this.activeFile;
+        const target = b.bookmarks[ index ];
+        if (!target) {
+            return;
+        }
+        const normalized = normalizeGroupId(newGroupId);
+        target.groupId = normalized;
+        this.onDidUpdateBookmarkEmitter.fire({
+            file: b,
+            index,
+            line: target.line + 1,
+            column: target.column + 1,
+            label: target.label,
+            groupId: normalized
+        });
     }
 
     public removeBookmark(index: number, aline: number, book?: File): void {
@@ -449,7 +484,12 @@ export class Controller {
                 }
 
                 for (const bkm of file.bookmarks) {
-                    bookmark.bookmarks.push(bkm);
+                    bookmark.bookmarks.push({
+                        line: bkm.line,
+                        column: bkm.column,
+                        label: bkm.label,
+                        groupId: normalizeGroupId(bkm.groupId)
+                    });
                 }
                 this.files.push(bookmark);
             }
@@ -483,7 +523,8 @@ export class Controller {
                     bookmark.bookmarks.push({
                         line: bkm.line,
                         column: bkm.column,
-                        label: bkm.label
+                        label: bkm.label,
+                        groupId: normalizeGroupId(bkm.groupId)
                     });
                 }
                 this.files.push(bookmark);
@@ -493,10 +534,13 @@ export class Controller {
 
         // NEWER v3 format
         for (const file of jsonObject.files) {
-            const bookmark = createFile(file.path);//??, file.uri ? <Uri>file.uri : undefined);
-            bookmark.bookmarks = [
-                ...file.bookmarks
-            ];
+            const bookmark = createFile(file.path);
+            bookmark.bookmarks = (file.bookmarks ?? []).map((bkm: Bookmark) => ({
+                line: bkm.line,
+                column: bkm.column,
+                label: bkm.label,
+                groupId: normalizeGroupId(bkm.groupId)
+            }));
             this.files.push(bookmark);
         }
     }

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -47,7 +47,6 @@ interface BookmarkUpdated {
     column?: number;
     linePreview?: string;
     label?: string;
-    groupId?: number;
 }
 
 enum ToggleMode {
@@ -359,24 +358,6 @@ export class Controller {
                 uri: this.getFileUri(b)
             });
         }
-    }
-
-    public changeGroup(index: number, newGroupId: number, book?: File): void {
-        const b: File = book ? book : this.activeFile;
-        const target = b.bookmarks[ index ];
-        if (!target) {
-            return;
-        }
-        const normalized = normalizeGroupId(newGroupId);
-        target.groupId = normalized;
-        this.onDidUpdateBookmarkEmitter.fire({
-            file: b,
-            index,
-            line: target.line + 1,
-            column: target.column + 1,
-            label: target.label,
-            groupId: normalized
-        });
     }
 
     public removeBookmark(index: number, aline: number, book?: File): void {

--- a/src/core/groupState.ts
+++ b/src/core/groupState.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { Event, EventEmitter, WorkspaceFolder } from "vscode";
+import { Container } from "./container";
+import { DEFAULT_GROUP_ID, MAX_GROUPS } from "./constants";
+
+const GLOBAL_SCOPE_KEY = "__global__";
+
+function storageKey(workspaceFolder: WorkspaceFolder | undefined): string {
+    const scope = workspaceFolder ? workspaceFolder.uri.toString() : GLOBAL_SCOPE_KEY;
+    return `bookmarks.activeGroupId.${scope}`;
+}
+
+const emitter = new EventEmitter<number>();
+
+export const onDidChangeActiveGroup: Event<number> = emitter.event;
+
+export function getActiveGroupId(workspaceFolder?: WorkspaceFolder): number {
+    const stored = Container.context.workspaceState.get<number>(storageKey(workspaceFolder), DEFAULT_GROUP_ID);
+    if (!Number.isFinite(stored) || stored < 0 || stored >= MAX_GROUPS) {
+        return DEFAULT_GROUP_ID;
+    }
+    return stored;
+}
+
+export async function setActiveGroupId(workspaceFolder: WorkspaceFolder | undefined, id: number): Promise<void> {
+    if (!Number.isFinite(id) || id < 0 || id >= MAX_GROUPS) {
+        return;
+    }
+    await Container.context.workspaceState.update(storageKey(workspaceFolder), id);
+    emitter.fire(id);
+}

--- a/src/core/groups.ts
+++ b/src/core/groups.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { ConfigurationChangeEvent, workspace } from "vscode";
+import {
+    DEFAULT_GROUP_COLORS,
+    DEFAULT_GROUP_NAMES,
+    DEFAULT_GUTTER_ICON_BORDER_COLOR,
+    DEFAULT_GUTTER_ICON_FILL_COLOR,
+    MAX_GROUPS
+} from "./constants";
+
+export interface BookmarkGroup {
+    id: number;
+    name: string;
+    color: string;
+    borderColor: string;
+}
+
+const HEX_COLOR = /^#[0-9a-fA-F]{3,8}$/;
+
+interface RawGroup {
+    id?: number;
+    name?: string;
+    color?: string;
+    borderColor?: string;
+}
+
+function isValidColor(value: unknown): value is string {
+    return typeof value === "string" && HEX_COLOR.test(value);
+}
+
+function defaultGroup(slot: number, legacyFill?: string, legacyBorder?: string): BookmarkGroup {
+    const id = slot;
+    const color = id === 0 && legacyFill && isValidColor(legacyFill)
+        ? legacyFill
+        : DEFAULT_GROUP_COLORS[slot];
+    const borderColor = id === 0 && legacyBorder && isValidColor(legacyBorder)
+        ? legacyBorder
+        : DEFAULT_GROUP_COLORS[slot];
+    return {
+        id,
+        name: DEFAULT_GROUP_NAMES[slot],
+        color,
+        borderColor
+    };
+}
+
+export function getGroups(): BookmarkGroup[] {
+    const cfg = workspace.getConfiguration("bookmarks");
+    const raw = cfg.get<RawGroup[]>("groups", []);
+    const legacyFill = cfg.get<string>("gutterIconFillColor", DEFAULT_GUTTER_ICON_FILL_COLOR);
+    const legacyBorder = cfg.get<string>("gutterIconBorderColor", DEFAULT_GUTTER_ICON_BORDER_COLOR);
+
+    const groups: BookmarkGroup[] = [];
+    for (let slot = 0; slot < MAX_GROUPS; slot++) {
+        groups.push(defaultGroup(slot, legacyFill, legacyBorder));
+    }
+
+    if (Array.isArray(raw)) {
+        for (const entry of raw) {
+            if (!entry || typeof entry !== "object") {
+                continue;
+            }
+            const id = typeof entry.id === "number" ? Math.floor(entry.id) : NaN;
+            if (!Number.isFinite(id) || id < 0 || id >= MAX_GROUPS) {
+                continue;
+            }
+            const slot = id;
+            const merged = groups[slot];
+            if (typeof entry.name === "string" && entry.name.length > 0) {
+                merged.name = entry.name;
+            }
+            if (isValidColor(entry.color)) {
+                merged.color = entry.color;
+                merged.borderColor = entry.color;
+            }
+            if (isValidColor(entry.borderColor)) {
+                merged.borderColor = entry.borderColor;
+            }
+        }
+    }
+
+    return groups;
+}
+
+export function getGroup(id: number): BookmarkGroup {
+    const groups = getGroups();
+    if (id < 0 || id >= MAX_GROUPS) {
+        return groups[0];
+    }
+    return groups[id];
+}
+
+export function groupsConfigChanged(e: ConfigurationChangeEvent): boolean {
+    return e.affectsConfiguration("bookmarks.groups")
+        || e.affectsConfiguration("bookmarks.gutterIconFillColor")
+        || e.affectsConfiguration("bookmarks.gutterIconBorderColor");
+}

--- a/src/decoration/decoration.ts
+++ b/src/decoration/decoration.ts
@@ -7,22 +7,36 @@ import { createLineDecoration } from "vscode-ext-decoration";
 import { workspace, ThemeColor, OverviewRulerLane, TextEditor, Range, TextEditorDecorationType, Uri, DecorationRenderOptions, window, DecorationOptions } from "vscode";
 import { Controller } from "../core/controller";
 import { indexOfBookmark } from "../core/operations";
-import { DEFAULT_GUTTER_ICON_BORDER_COLOR, DEFAULT_GUTTER_ICON_FILL_COLOR } from "../core/constants";
+import { DEFAULT_GROUP_ID, MAX_GROUPS } from "../core/constants";
 import { getOverviewRulerLaneConfig } from "../utils/overviewRulerLane";
 import { Bookmark } from "../core/bookmark";
+import { getGroups } from "../core/groups";
+
+export type GroupDecorationMap = Map<number, [TextEditorDecorationType, TextEditorDecorationType]>;
+
+function buildGutterIcon(fillColor: string, borderColor: string): Uri {
+    return Uri.parse(
+        `data:image/svg+xml,${encodeURIComponent(
+            `<?xml version="1.0" ?><svg height="16px" version="1.1" viewBox="0 0 16 16" width="16px" xmlns="http://www.w3.org/2000/svg" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns" xmlns:xlink="http://www.w3.org/1999/xlink"><title/><desc/><defs/><g fill="none" fill-rule="evenodd" id="Page-1" stroke="${borderColor}" stroke-width="1"><g fill="${fillColor}" id="icon-18-bookmark"><path d="m6.6319,2.13334c-0.82764,0 -1.49857,0.67089 -1.49857,1.49555l0,10.50444l2.99999,-3l3,3l0,-10.50444c0,-0.82597 -0.67081,-1.49555 -1.49858,-1.49555l-3.00285,0z" id="bookmark"/></g></g></svg>`,
+        )}`,
+    );
+}
+
+export function buildGroupGutterIcon(fillColor: string, borderColor: string): Uri {
+    return buildGutterIcon(fillColor, borderColor);
+}
 
 function createGutterRulerDecoration(
-    overviewRulerLane?: OverviewRulerLane,
-    overviewRulerColor?: string | ThemeColor,
-    gutterIconPath?: string | Uri): TextEditorDecorationType {
+    overviewRulerLane: OverviewRulerLane | undefined,
+    overviewRulerColor: string | ThemeColor,
+    gutterIconPath: Uri): TextEditorDecorationType {
 
     const decorationOptions: DecorationRenderOptions = {
         gutterIconPath,
         overviewRulerLane,
-        overviewRulerColor: overviewRulerLane !== undefined ? overviewRulerColor : undefined
+        overviewRulerColor: overviewRulerLane !== undefined ? overviewRulerColor : undefined,
+        isWholeLine: false
     };
-
-    decorationOptions.isWholeLine = false;
 
     return window.createTextEditorDecorationType(decorationOptions);
 }
@@ -44,24 +58,28 @@ export function createBookmarkLabelInlineDecoration(): TextEditorDecorationType 
     return window.createTextEditorDecorationType(decorationOptions);
 }
 
-export function createBookmarkDecorations(): TextEditorDecorationType[] {
-    const iconFillColor = workspace.getConfiguration("bookmarks").get("gutterIconFillColor", DEFAULT_GUTTER_ICON_FILL_COLOR);
-    const iconBorderColor = workspace.getConfiguration("bookmarks").get("gutterIconBorderColor", DEFAULT_GUTTER_ICON_BORDER_COLOR);
-    const iconPath = Uri.parse(
-        `data:image/svg+xml,${encodeURIComponent(
-            `<?xml version="1.0" ?><svg height="16px" version="1.1" viewBox="0 0 16 16" width="16px" xmlns="http://www.w3.org/2000/svg" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns" xmlns:xlink="http://www.w3.org/1999/xlink"><title/><desc/><defs/><g fill="none" fill-rule="evenodd" id="Page-1" stroke="${iconBorderColor}" stroke-width="1"><g fill="${iconFillColor}" id="icon-18-bookmark"><path d="m6.6319,2.13334c-0.82764,0 -1.49857,0.67089 -1.49857,1.49555l0,10.50444l2.99999,-3l3,3l0,-10.50444c0,-0.82597 -0.67081,-1.49555 -1.49858,-1.49555l-3.00285,0z" id="bookmark"/></g></g></svg>`,
-        )}`,
-    );
-    
-    const overviewRulerColor = new ThemeColor('bookmarks.overviewRuler');
-    const lineBackground = new ThemeColor('bookmarks.lineBackground');
-    const lineBorder = new ThemeColor('bookmarks.lineBorder');
-
+export function createBookmarkDecorationsForGroups(): GroupDecorationMap {
+    const overviewRulerColor = new ThemeColor("bookmarks.overviewRuler");
+    const lineBackground = new ThemeColor("bookmarks.lineBackground");
+    const lineBorder = new ThemeColor("bookmarks.lineBorder");
     const overviewRulerLane = getOverviewRulerLaneConfig();
 
-    const gutterDecoration = createGutterRulerDecoration(overviewRulerLane, overviewRulerColor, iconPath);
-    const lineDecoration = createLineDecoration(lineBackground, lineBorder);
-    return [gutterDecoration, lineDecoration];
+    const map: GroupDecorationMap = new Map();
+    for (const group of getGroups()) {
+        const iconPath = buildGutterIcon(group.color, group.borderColor);
+        const gutterDecoration = createGutterRulerDecoration(overviewRulerLane, overviewRulerColor, iconPath);
+        const lineDecoration = createLineDecoration(lineBackground, lineBorder);
+        map.set(group.id, [gutterDecoration, lineDecoration]);
+    }
+    return map;
+}
+
+export function disposeGroupDecorations(map: GroupDecorationMap): void {
+    for (const pair of map.values()) {
+        pair[0].dispose();
+        pair[1].dispose();
+    }
+    map.clear();
 }
 
 function buildDecorationOptionsForInlineBookmarkLabel(
@@ -69,8 +87,8 @@ function buildDecorationOptionsForInlineBookmarkLabel(
     bookmark: Bookmark,
 ): DecorationOptions {
     const elementLineRange = activeEditor.document.lineAt(bookmark.line).range;
-    const decorationOptionsForLabel : DecorationOptions = {
-        range : new Range(
+    const decorationOptionsForLabel: DecorationOptions = {
+        range: new Range(
             elementLineRange.start.line,
             elementLineRange.end.character,
             elementLineRange.start.line,
@@ -89,7 +107,7 @@ function buildDecorationOptionsForInlineBookmarkLabel(
 export function updateDecorationsInActiveEditor(
     activeEditor: TextEditor,
     bookmarks: Controller,
-    bookmarkDecorationType: TextEditorDecorationType[],
+    groupDecorations: GroupDecorationMap,
     bookmarkLabelInlineDecoration: TextEditorDecorationType,
 ) {
     if (!activeEditor) {
@@ -100,50 +118,70 @@ export function updateDecorationsInActiveEditor(
         return;
     }
 
+    const clearAll = () => {
+        for (const pair of groupDecorations.values()) {
+            activeEditor.setDecorations(pair[0], []);
+            activeEditor.setDecorations(pair[1], []);
+        }
+        activeEditor.setDecorations(bookmarkLabelInlineDecoration, []);
+    };
+
     if (bookmarks.activeFile.bookmarks.length === 0) {
-        const bks: Range[] = [];
-      
-        bookmarkDecorationType.forEach(d => activeEditor.setDecorations(d, bks));
+        clearAll();
         return;
     }
-
-    const decorationRanges: Range[] = [];
-    const decorationOptionsForLabels: DecorationOptions[] = [];
-
-    const bookmarksLabelInlineEnabled = workspace.getConfiguration("bookmarks").get("label.inline.enabled", false);
 
     // Remove all bookmarks if active file is empty
     if (activeEditor.document.lineCount === 1 && activeEditor.document.lineAt(0).text === "") {
         bookmarks.activeFile.bookmarks = [];
-    } else {
-        const invalids = [];
-        for (const bookmark of bookmarks.activeFile.bookmarks) {
+        clearAll();
+        return;
+    }
 
-            if (bookmark.line <= activeEditor.document.lineCount) { 
-                const decorationRange = new Range(bookmark.line, 0, bookmark.line, 0);
-                decorationRanges.push(decorationRange);
+    const bookmarksLabelInlineEnabled = workspace.getConfiguration("bookmarks").get("label.inline.enabled", false);
 
-                if (bookmarksLabelInlineEnabled && bookmark.label !== undefined && bookmark.label.length > 0) {
-                    decorationOptionsForLabels.push(buildDecorationOptionsForInlineBookmarkLabel(
-                        activeEditor,
-                        bookmark,
-                    ));
-                }
-            } else {
-                invalids.push(bookmark);
+    const rangesByGroup: Map<number, Range[]> = new Map();
+    const decorationOptionsForLabels: DecorationOptions[] = [];
+    const invalids: Bookmark[] = [];
+
+    for (const bookmark of bookmarks.activeFile.bookmarks) {
+        if (bookmark.line <= activeEditor.document.lineCount) {
+            const groupId = (bookmark.groupId && groupDecorations.has(bookmark.groupId))
+                ? bookmark.groupId
+                : DEFAULT_GROUP_ID;
+            const ranges = rangesByGroup.get(groupId) ?? [];
+            ranges.push(new Range(bookmark.line, 0, bookmark.line, 0));
+            rangesByGroup.set(groupId, ranges);
+
+            if (bookmarksLabelInlineEnabled && bookmark.label !== undefined && bookmark.label.length > 0) {
+                decorationOptionsForLabels.push(buildDecorationOptionsForInlineBookmarkLabel(
+                    activeEditor,
+                    bookmark,
+                ));
             }
+        } else {
+            invalids.push(bookmark);
         }
+    }
 
-        if (invalids.length > 0) {
-            let idxInvalid: number;
-            for (const element of invalids) {
-                idxInvalid = indexOfBookmark(bookmarks.activeFile, element); 
+    if (invalids.length > 0) {
+        for (const element of invalids) {
+            const idxInvalid = indexOfBookmark(bookmarks.activeFile, element.line);
+            if (idxInvalid > -1) {
                 bookmarks.activeFile.bookmarks.splice(idxInvalid, 1);
             }
         }
     }
-    // Add common decorations (gutter icons/line highlights)
-    bookmarkDecorationType.forEach(d => activeEditor.setDecorations(d, decorationRanges));
-    // Add label inline text decorations
+
+    for (let id = 0; id < MAX_GROUPS; id++) {
+        const pair = groupDecorations.get(id);
+        if (!pair) {
+            continue;
+        }
+        const ranges = rangesByGroup.get(id) ?? [];
+        activeEditor.setDecorations(pair[0], ranges);
+        activeEditor.setDecorations(pair[1], ranges);
+    }
+
     activeEditor.setDecorations(bookmarkLabelInlineDecoration, decorationOptionsForLabels);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,11 @@ import { BookmarkQuickPickItem } from "./core/bookmark";
 import { NO_BOOKMARKS_AFTER, NO_BOOKMARKS_BEFORE, NO_MORE_BOOKMARKS } from "./core/constants";
 import { Directions, isWindows, SEARCH_EDITOR_SCHEME } from "./core/constants";
 import { Container } from "./core/container";
-import { createBookmarkDecorations, createBookmarkLabelInlineDecoration, updateDecorationsInActiveEditor } from "./decoration/decoration";
+import { createBookmarkDecorationsForGroups, createBookmarkLabelInlineDecoration, disposeGroupDecorations, GroupDecorationMap, updateDecorationsInActiveEditor } from "./decoration/decoration";
+import { MAX_GROUPS } from "./core/constants";
+import { getGroup, getGroups, groupsConfigChanged } from "./core/groups";
+import { getActiveGroupId, setActiveGroupId } from "./core/groupState";
+import { registerActiveGroupStatusBar } from "./statusBar/activeGroup";
 import { File } from "./core/file";
 import { Controller } from "./core/controller";
 import { indexOfBookmark, listBookmarks, nextBookmark, sortBookmarks } from "./core/operations";
@@ -65,22 +69,18 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async cfg => {
         // Allow change the gutterIcon and inline label decoration without reload
-        if (cfg.affectsConfiguration("bookmarks.gutterIconFillColor") ||
-            cfg.affectsConfiguration("bookmarks.gutterIconBorderColor") ||
+        if (groupsConfigChanged(cfg) ||
             cfg.affectsConfiguration("bookmarks.overviewRulerLane") ||
             cfg.affectsConfiguration("bookmarks.label.inline.enabled") ||
             cfg.affectsConfiguration("bookmarks.label.inline.margin") ||
             cfg.affectsConfiguration("bookmarks.label.inline.fontStyle") ||
             cfg.affectsConfiguration("bookmarks.label.inline.fontWeight")
         ) {
-            if (bookmarkDecorationType.length > 0) {
-                bookmarkDecorationType.forEach(b => b.dispose());
-            }
+            disposeGroupDecorations(bookmarkDecorationType);
             bookmarkLabelInlineDecoration.dispose();
 
-            bookmarkDecorationType = createBookmarkDecorations();
+            bookmarkDecorationType = createBookmarkDecorationsForGroups();
             bookmarkLabelInlineDecoration = createBookmarkLabelInlineDecoration();
-            context.subscriptions.push(...bookmarkDecorationType);
             context.subscriptions.push(bookmarkLabelInlineDecoration);
 
             updateDecorations();
@@ -174,9 +174,8 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     }));
 
-    let bookmarkDecorationType = createBookmarkDecorations();
+    let bookmarkDecorationType: GroupDecorationMap = createBookmarkDecorationsForGroups();
     let bookmarkLabelInlineDecoration = createBookmarkLabelInlineDecoration();
-    context.subscriptions.push(...bookmarkDecorationType);
     context.subscriptions.push(bookmarkLabelInlineDecoration);
 
     // Connect it to the Editors Events
@@ -425,6 +424,82 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("bookmarks.jumpToPrevious", () => jumpToNext(Directions.Backward));
     vscode.commands.registerCommand("bookmarks.list", () => list());
     vscode.commands.registerCommand("bookmarks.listFromAllFiles", () => listFromAllFiles());
+
+    vscode.commands.registerCommand("bookmarks.switchActiveGroup", async () => {
+        const wsf = activeController?.workspaceFolder;
+        const currentId = getActiveGroupId(wsf);
+        const items = getGroups().map(group => ({
+            label: `$(bookmark) ${group.name}`,
+            description: group.id === currentId ? vscode.l10n.t("(active)") : undefined,
+            detail: group.color,
+            groupId: group.id
+        }));
+        const selection = await vscode.window.showQuickPick(items, {
+            placeHolder: vscode.l10n.t("Select active bookmark group")
+        });
+        if (!selection) {
+            return;
+        }
+        await setActiveGroupId(wsf, selection.groupId);
+        const chosen = getGroup(selection.groupId);
+        vscode.window.setStatusBarMessage(vscode.l10n.t("Active bookmark group set to {0}", chosen.name), 2000);
+    });
+
+    for (let n = 0; n < MAX_GROUPS; n++) {
+        const groupId = n;
+        vscode.commands.registerCommand(`bookmarks.toggleGroup${n}`, async () => {
+            await toggleOrSetGroup(groupId);
+        });
+    }
+
+    registerActiveGroupStatusBar(() => activeController?.workspaceFolder);
+
+    async function toggleOrSetGroup(groupId: number) {
+        if (!vscode.window.activeTextEditor) {
+            const wsf = activeController?.workspaceFolder;
+            await setActiveGroupId(wsf, groupId);
+            const chosen = getGroup(groupId);
+            vscode.window.setStatusBarMessage(vscode.l10n.t("Active bookmark group set to {0}", chosen.name), 2000);
+            return;
+        }
+
+        if (!activeController.activeFile) {
+            activeController.addFile(vscode.window.activeTextEditor.document.uri);
+            activeController.activeFile = activeController.fromUri(vscode.window.activeTextEditor.document.uri);
+        }
+
+        const file = activeController.activeFile;
+        const selections = vscode.window.activeTextEditor.selections;
+
+        const changedLines = new Set<number>();
+        let anyChanged = false;
+        for (const sel of selections) {
+            const line = sel.active.line;
+            if (changedLines.has(line)) {
+                continue;
+            }
+            const idx = indexOfBookmark(file, line);
+            if (idx > -1) {
+                activeController.changeGroup(idx, groupId);
+                changedLines.add(line);
+                anyChanged = true;
+            }
+        }
+
+        if (anyChanged) {
+            saveWorkspaceState();
+            updateDecorations();
+            const chosen = getGroup(groupId);
+            vscode.window.setStatusBarMessage(vscode.l10n.t("Bookmark moved to group {0}", chosen.name), 2000);
+            return;
+        }
+
+        // No selections had a bookmark — set active group instead
+        const wsf = activeController.workspaceFolder;
+        await setActiveGroupId(wsf, groupId);
+        const chosen = getGroup(groupId);
+        vscode.window.setStatusBarMessage(vscode.l10n.t("Active bookmark group set to {0}", chosen.name), 2000);
+    }
 
     function getActiveController(document: TextDocument): void {
         // system files don't have workspace, so use the first one [0]
@@ -938,10 +1013,13 @@ export async function activate(context: vscode.ExtensionContext) {
                 vscode.window.showWarningMessage(vscode.l10n.t("You must define a label for the bookmark."));
                 return;
             }
+            let preservedGroupId: number | undefined;
             if (index >= 0) {
+                const existing = (book ?? activeController.activeFile).bookmarks[ index ];
+                preservedGroupId = existing?.groupId;
                 activeController.removeBookmark(index, position.line, book);
             }
-            activeController.addBookmark(position, bookmarkLabel, book);
+            activeController.addBookmark(position, bookmarkLabel, book, preservedGroupId ?? getActiveGroupId(activeController.workspaceFolder));
 
             // toggle editing mode
             if (jumpToPosition) {
@@ -985,7 +1063,7 @@ export async function activate(context: vscode.ExtensionContext) {
             activeController.activeFile = activeController.fromUri(vscode.window.activeTextEditor.document.uri);
         }
 
-        if (await activeController.toggle(selections)) {
+        if (await activeController.toggle(selections, undefined, undefined, getActiveGroupId(activeController.workspaceFolder))) {
             if (!isInDiffEditor()) {
                 vscode.window.showTextDocument(vscode.window.activeTextEditor.document, { preview: false, viewColumn: vscode.window.activeTextEditor.viewColumn });
             }
@@ -1023,7 +1101,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         let suggestion = suggestLabel(vscode.window.activeTextEditor.selection);
         if (!params && suggestion !== "" && useSelectionWhenAvailable()) {
-            if (await activeController.toggle(selections, suggestion)) {
+            if (await activeController.toggle(selections, suggestion, undefined, getActiveGroupId(activeController.workspaceFolder))) {
                 vscode.window.showTextDocument(vscode.window.activeTextEditor.document, { preview: false, viewColumn: vscode.window.activeTextEditor.viewColumn });
             }
             sortBookmarks(activeController.activeFile);
@@ -1057,7 +1135,7 @@ export async function activate(context: vscode.ExtensionContext) {
             return;
         }
 
-        if (await activeController.toggle(selections, newLabel)) {
+        if (await activeController.toggle(selections, newLabel, undefined, getActiveGroupId(activeController.workspaceFolder))) {
             vscode.window.showTextDocument(vscode.window.activeTextEditor.document, { preview: false, viewColumn: vscode.window.activeTextEditor.viewColumn });
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,6 @@ import { NO_BOOKMARKS_AFTER, NO_BOOKMARKS_BEFORE, NO_MORE_BOOKMARKS } from "./co
 import { Directions, isWindows, SEARCH_EDITOR_SCHEME } from "./core/constants";
 import { Container } from "./core/container";
 import { createBookmarkDecorationsForGroups, createBookmarkLabelInlineDecoration, disposeGroupDecorations, GroupDecorationMap, updateDecorationsInActiveEditor } from "./decoration/decoration";
-import { MAX_GROUPS } from "./core/constants";
 import { getGroup, getGroups, groupsConfigChanged } from "./core/groups";
 import { getActiveGroupId, setActiveGroupId } from "./core/groupState";
 import { registerActiveGroupStatusBar } from "./statusBar/activeGroup";
@@ -445,61 +444,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.window.setStatusBarMessage(vscode.l10n.t("Active bookmark group set to {0}", chosen.name), 2000);
     });
 
-    for (let n = 0; n < MAX_GROUPS; n++) {
-        const groupId = n;
-        vscode.commands.registerCommand(`bookmarks.toggleGroup${n}`, async () => {
-            await toggleOrSetGroup(groupId);
-        });
-    }
-
     registerActiveGroupStatusBar(() => activeController?.workspaceFolder);
-
-    async function toggleOrSetGroup(groupId: number) {
-        if (!vscode.window.activeTextEditor) {
-            const wsf = activeController?.workspaceFolder;
-            await setActiveGroupId(wsf, groupId);
-            const chosen = getGroup(groupId);
-            vscode.window.setStatusBarMessage(vscode.l10n.t("Active bookmark group set to {0}", chosen.name), 2000);
-            return;
-        }
-
-        if (!activeController.activeFile) {
-            activeController.addFile(vscode.window.activeTextEditor.document.uri);
-            activeController.activeFile = activeController.fromUri(vscode.window.activeTextEditor.document.uri);
-        }
-
-        const file = activeController.activeFile;
-        const selections = vscode.window.activeTextEditor.selections;
-
-        const changedLines = new Set<number>();
-        let anyChanged = false;
-        for (const sel of selections) {
-            const line = sel.active.line;
-            if (changedLines.has(line)) {
-                continue;
-            }
-            const idx = indexOfBookmark(file, line);
-            if (idx > -1) {
-                activeController.changeGroup(idx, groupId);
-                changedLines.add(line);
-                anyChanged = true;
-            }
-        }
-
-        if (anyChanged) {
-            saveWorkspaceState();
-            updateDecorations();
-            const chosen = getGroup(groupId);
-            vscode.window.setStatusBarMessage(vscode.l10n.t("Bookmark moved to group {0}", chosen.name), 2000);
-            return;
-        }
-
-        // No selections had a bookmark — set active group instead
-        const wsf = activeController.workspaceFolder;
-        await setActiveGroupId(wsf, groupId);
-        const chosen = getGroup(groupId);
-        vscode.window.setStatusBarMessage(vscode.l10n.t("Active bookmark group set to {0}", chosen.name), 2000);
-    }
 
     function getActiveController(document: TextDocument): void {
         // system files don't have workspace, so use the first one [0]

--- a/src/sidebar/bookmarkNode.ts
+++ b/src/sidebar/bookmarkNode.ts
@@ -3,10 +3,12 @@
 *  Licensed under the GPLv3 License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { Command, TreeItem, TreeItemCollapsibleState, Uri, workspace } from "vscode";
-import { DEFAULT_GUTTER_ICON_BORDER_COLOR, DEFAULT_GUTTER_ICON_FILL_COLOR } from "../core/constants";
+import { Command, TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
+import { DEFAULT_GROUP_ID } from "../core/constants";
 import { File } from "../core/file";
+import { getGroup } from "../core/groups";
 import { BookmarkNodeKind } from "./nodes";
+import { buildGroupGutterIcon } from "../decoration/decoration";
 
 export interface BookmarkPreview {
     file: string;
@@ -14,6 +16,7 @@ export interface BookmarkPreview {
     column: number;
     preview: string;
     uri: Uri;
+    groupId: number;
 }
 
 export class BookmarkNode extends TreeItem {
@@ -25,19 +28,14 @@ export class BookmarkNode extends TreeItem {
         public readonly kind: BookmarkNodeKind,
         public readonly bookmark: File,
         public readonly books?: BookmarkPreview[],
-        public readonly command?: Command
+        public readonly command?: Command,
+        public readonly groupId: number = DEFAULT_GROUP_ID
     ) {
         super(label, collapsibleState);
 
         this.description = relativePath;
-        const iconFillColor = workspace.getConfiguration("bookmarks").get("gutterIconFillColor", DEFAULT_GUTTER_ICON_FILL_COLOR);
-        const iconBorderColor = workspace.getConfiguration("bookmarks").get("gutterIconBorderColor", DEFAULT_GUTTER_ICON_BORDER_COLOR);
-        const iconPath = Uri.parse(
-            `data:image/svg+xml,${encodeURIComponent(
-                `<?xml version="1.0" ?><svg height="16px" version="1.1" viewBox="0 0 16 16" width="16px" xmlns="http://www.w3.org/2000/svg" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns" xmlns:xlink="http://www.w3.org/1999/xlink"><title/><desc/><defs/><g fill="none" fill-rule="evenodd" id="Page-1" stroke="${iconBorderColor}" stroke-width="1"><g fill="${iconFillColor}" id="icon-18-bookmark"><path d="m6.6319,2.13334c-0.82764,0 -1.49857,0.67089 -1.49857,1.49555l0,10.50444l2.99999,-3l3,3l0,-10.50444c0,-0.82597 -0.67081,-1.49555 -1.49858,-1.49555l-3.00285,0z" id="bookmark"/></g></g></svg>`,
-            )}`,
-        );
-        this.iconPath = iconPath;
+        const group = getGroup(groupId);
+        this.iconPath = buildGroupGutterIcon(group.color, group.borderColor);
         this.contextValue = "BookmarkNodeBookmark";
     }
 }

--- a/src/sidebar/bookmarkProvider.ts
+++ b/src/sidebar/bookmarkProvider.ts
@@ -6,32 +6,41 @@
 import path = require("path");
 import * as vscode from "vscode";
 import { Controller } from "../core/controller";
-import { parsePosition, Point } from "./parser";
 import { codicons } from "vscode-ext-codicons";
-import { listBookmarks } from "../core/operations";
 import { Container } from "../core/container";
 import { FileNode } from "./fileNode";
 import { BookmarkNode, BookmarkPreview } from "./bookmarkNode";
 import { WorkspaceNode } from "./workspaceNode";
+import { GroupNode } from "./groupNode";
 import { BookmarkNodeKind } from "./nodes";
-import { BadgeConfig } from "../core/constants";
+import { BadgeConfig, DEFAULT_GROUP_ID } from "../core/constants";
+import { Bookmark } from "../core/bookmark";
+import { File } from "../core/file";
+import { getGroups } from "../core/groups";
+import { getActiveGroupId, onDidChangeActiveGroup } from "../core/groupState";
+import { getFileUri } from "../utils/fs";
 
-export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode | WorkspaceNode | FileNode> {
+type SidebarNode = BookmarkNode | WorkspaceNode | FileNode | GroupNode;
 
-    private _onDidChangeTreeData: vscode.EventEmitter<BookmarkNode | void> = new vscode.EventEmitter<BookmarkNode | void>();
-    public readonly onDidChangeTreeData: vscode.Event<BookmarkNode | void> = this._onDidChangeTreeData.event;
+export class BookmarkProvider implements vscode.TreeDataProvider<SidebarNode> {
 
-    private tree: BookmarkNode[] = [];
+    private _onDidChangeTreeData: vscode.EventEmitter<SidebarNode | void> = new vscode.EventEmitter<SidebarNode | void>();
+    public readonly onDidChangeTreeData: vscode.Event<SidebarNode | void> = this._onDidChangeTreeData.event;
 
     private collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+    private controllerListeners: vscode.Disposable[] = [];
+    private activeGroupListener: vscode.Disposable;
 
     constructor(private controllers: Controller[]) {
-
         if (vscode.workspace.getConfiguration("bookmarks.sideBar").get<boolean>("expanded", false)) {
             this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
         }
 
         this.registerControllerListeners(controllers);
+
+        this.activeGroupListener = onDidChangeActiveGroup(() => {
+            this._onDidChangeTreeData.fire();
+        });
     }
 
     public updateControllers(controllers: Controller[]): void {
@@ -41,132 +50,24 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode | 
     }
 
     private registerControllerListeners(controllers: Controller[]): void {
-
-        for (const controller of controllers) {
-            controller.onDidClearBookmarks(() => {
-                this._onDidChangeTreeData.fire();
-            });
+        for (const d of this.controllerListeners) {
+            d.dispose();
         }
+        this.controllerListeners = [];
 
         for (const controller of controllers) {
-
-            controller.onDidAddBookmark(bkm => {
-
-                // no bookmark in this file
-                if (this.tree.length === 0) {
-                    this._onDidChangeTreeData.fire();
-                    return;
-                }
-
-                // has bookmarks - find it
-                for (const bn of this.tree) {
-                    if (bn.bookmark === bkm.file) {
-
-                        if (!bkm.label) {
-                            bn.books.push({
-                                file: bn.books[ 0 ].file,
-                                line: bkm.line,
-                                column: bkm.column,
-                                preview: bkm.linePreview,
-                                uri: bkm.uri
-                            });
-                        } else {
-                            bn.books.push({
-                                file: bn.books[ 0 ].file,
-                                line: bkm.line,
-                                column: bkm.column,
-                                preview: "\u270E " + bkm.label,
-                                uri: bkm.uri
-                            });
-                        }
-
-                        bn.books.sort((n1, n2) => {
-                            if (n1.line > n2.line) {
-                                return 1;
-                            }
-
-                            if (n1.line < n2.line) {
-                                return -1;
-                            }
-
-                            return 0;
-                        });
-
-                        this._onDidChangeTreeData.fire(bn);
-                        return;
-                    }
-                }
-
-                // not found - new file
-                this._onDidChangeTreeData.fire();
-            });
-        }
-
-
-        for (const controller of controllers) {
-
-            controller.onDidRemoveBookmark(bkm => {
-
-                // no bookmark in this file
-                if (this.tree.length === 0) {
-                    this._onDidChangeTreeData.fire();
-                    return;
-                }
-
-                // has bookmarks - find it
-                for (const bn of this.tree) {
-                    if (bn.bookmark === bkm.bookmark) {
-
-                        // last one - reset
-                        if (bn.books.length === 1) {
-                            this._onDidChangeTreeData.fire(null);
-                            return;
-                        }
-
-                        // remove just that one
-                        for (let index = 0; index < bn.books.length; index++) {
-                            const element = bn.books[ index ];
-                            if (element.line === bkm.line) {
-                                bn.books.splice(index, 1);
-                                this._onDidChangeTreeData.fire(bn);
-                                return;
-                            }
-                        }
-                    }
-                }
-            });
-        }
-
-        for (const controller of controllers) {
-
-            controller.onDidUpdateBookmark(bkm => {
-
-                // no bookmark in this file
-                if (this.tree.length === 0) {
-                    this._onDidChangeTreeData.fire();
-                    return;
-                }
-
-                // has bookmarks - find it
-                for (const bn of this.tree) {
-                    if (bn.bookmark === bkm.file) {
-
-                        bn.books[ bkm.index ].line = bkm.line;
-                        bn.books[ bkm.index ].column = bkm.column ? bkm.column : bn.books[ bkm.index ].column;
-                        if (bkm.linePreview) {
-                            bn.books[ bkm.index ].preview = bkm.linePreview;
-                        } else {
-                            bn.books[ bkm.index ].preview = "\u270E " + bkm.label;
-                        }
-
-                        this._onDidChangeTreeData.fire(bn);
-                        return;
-                    }
-                }
-
-                // not found - new file
-                this._onDidChangeTreeData.fire();
-            });
+            this.controllerListeners.push(
+                controller.onDidClearBookmarks(() => this._onDidChangeTreeData.fire())
+            );
+            this.controllerListeners.push(
+                controller.onDidAddBookmark(() => this._onDidChangeTreeData.fire())
+            );
+            this.controllerListeners.push(
+                controller.onDidRemoveBookmark(() => this._onDidChangeTreeData.fire())
+            );
+            this.controllerListeners.push(
+                controller.onDidUpdateBookmark(() => this._onDidChangeTreeData.fire())
+            );
         }
     }
 
@@ -174,203 +75,165 @@ export class BookmarkProvider implements vscode.TreeDataProvider<BookmarkNode | 
         this._onDidChangeTreeData.fire();
     }
 
-    public getTreeItem(element: BookmarkNode): vscode.TreeItem {
+    public dispose(): void {
+        for (const d of this.controllerListeners) {
+            d.dispose();
+        }
+        this.activeGroupListener?.dispose();
+    }
+
+    public getTreeItem(element: SidebarNode): vscode.TreeItem {
         return element;
     }
 
-    // very much based in `listFromAllFiles` command
-    public getChildren(element?: FileNode | WorkspaceNode): Thenable<BookmarkNode[] | WorkspaceNode[] | FileNode[]> {
-
-        // no bookmark
-        // let totalBookmarkCount = 0;
-
-        let someFileHasBookmark: boolean;
+    public getChildren(element?: SidebarNode): Thenable<SidebarNode[]> {
+        let anyHasBookmark = false;
         for (const controller of this.controllers) {
-            someFileHasBookmark = controller.hasAnyBookmark();
-            if (someFileHasBookmark) { break; }
+            if (controller.hasAnyBookmark()) {
+                anyHasBookmark = true;
+                break;
+            }
         }
 
-        if (!someFileHasBookmark) {
-            this.tree = [];
+        if (!anyHasBookmark) {
             return Promise.resolve([]);
         }
 
-        // loop !!!
-        return new Promise(resolve => {
+        const viewAsList = Container.context.globalState.get<boolean>("viewAsList", false);
+        const hidePosition = Container.context.globalState.get<boolean>("bookmarks.sidebar.hidePosition", false);
+        const hideEmpty = vscode.workspace.getConfiguration("bookmarks.groups").get<boolean>("hideEmpty", false);
 
-            if (element) {
-
-                if (element.kind === BookmarkNodeKind.NODE_WORKSPACE_FOLDER) {
-
-                    const promisses = [];
-                    const ne = <WorkspaceNode>element;
-                    for (const file of ne.controller.files) {
-                        const pp = listBookmarks(file, ne.controller.workspaceFolder);
-                        promisses.push(pp);
-                    }
-
-                    Promise.all(promisses).then(
-                        (values) => {
-
-                            // raw list
-                            const lll: FileNode[] = [];
-                            for (const bb of ne.controller.files) {
-
-                                // this bookmark has bookmarks?
-                                if (bb.bookmarks.length > 0) {
-
-                                    const books: BookmarkPreview[] = [];
-
-                                    // search from `values`no
-                                    for (const elm of values) {
-                                        if (elm) {
-                                            for (const elementInside of elm) {
-
-                                                if (bb.path === elementInside.detail) {
-
-                                                    const point: Point = parsePosition(elementInside.description);
-                                                    books.push(
-                                                        {
-                                                            file: elementInside.detail,
-                                                            line: point.line,
-                                                            column: point.column,
-                                                            preview: elementInside.label.replace(codicons.tag, "\u270E"),
-                                                            uri: elementInside.uri
-                                                        }
-                                                    );
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    const itemPath = path.basename(bb.path);
-                                    const bn: FileNode = new FileNode(itemPath, removeRelativePathFromFile(bb.path), this.collapsibleState, BookmarkNodeKind.NODE_FILE, bb, books);
-                                    lll.push(bn);
-                                    // this.tree.push(bn);
-                                }
-                            }
-
-                            resolve(lll);
-                        }
-                    );
-                    return;
-                }
-
-                if (element.kind === BookmarkNodeKind.NODE_FILE) {
-                    const ll: BookmarkNode[] = [];
-
-                    const ne = <BookmarkNode>element;
-
-                    const hidePosition = Container.context.globalState.get<boolean>("bookmarks.sidebar.hidePosition", false);
-
-                    for (const bbb of ne.books) {
-                        ll.push(new BookmarkNode(bbb.preview, !hidePosition ? `(Ln ${bbb.line}, Col ${bbb.column})` : undefined, vscode.TreeItemCollapsibleState.None, BookmarkNodeKind.NODE_BOOKMARK, null, [], {
-                            command: "_bookmarks.jumpTo",
-                            title: "",
-                            arguments: [ bbb.file, bbb.line, bbb.column, bbb.uri ],
-                        }));
-                    }
-
-                    resolve(ll);
-                } else {
-                    resolve([]);
-                }
-            } else { // ROOT
-
-                //
-                const viewAsList = Container.context.globalState.get<boolean>("viewAsList", false);
-
-                // has more than one controller/worskpace and View As TREE, just loop through the controllers and returns its workspaces
-                if (this.controllers.length > 1 && !viewAsList) {
-                    const workspaces = [];
-                    for (const controller of this.controllers) {
-                        const wn: WorkspaceNode = new WorkspaceNode(controller.workspaceFolder.name, controller.workspaceFolder,
-                            this.collapsibleState, BookmarkNodeKind.NODE_WORKSPACE_FOLDER, [], controller);
-                        workspaces.push(wn);
-                    }
-                    resolve(workspaces);
-                    return;
-                }
-
-                this.tree = [];
-                const promisses = [];
-
-                // get all files, from all controllers/workspaces
+        if (!element) {
+            // ROOT: multi-root tree mode → WorkspaceNode[]; otherwise GroupNode[]
+            if (this.controllers.length > 1 && !viewAsList) {
+                const workspaces: WorkspaceNode[] = [];
                 for (const controller of this.controllers) {
-                    for (const file of controller.files) {
-                        const pp = listBookmarks(file, controller.workspaceFolder);
-                        promisses.push(pp);
-                    }
+                    const wn = new WorkspaceNode(
+                        controller.workspaceFolder.name,
+                        controller.workspaceFolder,
+                        this.collapsibleState,
+                        BookmarkNodeKind.NODE_WORKSPACE_FOLDER,
+                        [],
+                        controller
+                    );
+                    workspaces.push(wn);
                 }
-
-                // all files, from all controllers/workspaces
-                Promise.all(promisses).then(
-                    (values) => {
-
-                        // raw list
-                        const lll: FileNode[] = [];
-                        for (const controller of this.controllers) {
-                            for (const bb of controller.files) {
-
-                                // this bookmark has bookmarks?
-                                if (bb.bookmarks.length > 0) {
-
-                                    const books: BookmarkPreview[] = [];
-
-                                    // search from `values`no
-                                    for (const elm of values) {
-                                        if (elm) {
-                                            for (const elementInside of elm) {
-
-                                                if (bb.path === elementInside.detail) {
-
-                                                    const point: Point = parsePosition(elementInside.description);
-                                                    books.push(
-                                                        {
-                                                            file: elementInside.detail,
-                                                            line: point.line,
-                                                            column: point.column,
-                                                            preview: elementInside.label.replace(codicons.tag, "\u270E"),
-                                                            uri: elementInside.uri
-                                                        }
-                                                    );
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    const itemPath = path.basename(bb.path);
-                                    const bn: FileNode = new FileNode(itemPath, removeRelativePathFromFile(bb.path), this.collapsibleState, BookmarkNodeKind.NODE_FILE, bb, books);
-                                    lll.push(bn);
-                                    // this.tree.push(bn);
-                                }
-                            }
-                        }
-
-                        // choose the view
-                        if (viewAsList) {
-                            const hidePosition = Container.context.globalState.get<boolean>("bookmarks.sidebar.hidePosition", false);
-                            const bookmarkNodes: BookmarkNode[] = [];
-                            lll.forEach(FileNode => {
-                                for (const bbb of FileNode.books) {
-                                    bookmarkNodes.push(new BookmarkNode(bbb.preview, !hidePosition ? `(Ln ${bbb.line}, Col ${bbb.column})` : undefined, vscode.TreeItemCollapsibleState.None, BookmarkNodeKind.NODE_BOOKMARK, null, [], {
-                                        command: "_bookmarks.jumpTo",
-                                        title: "",
-                                        arguments: [ bbb.file, bbb.line, bbb.column, bbb.uri ],
-                                    }));
-                                }
-                            });
-                            resolve(bookmarkNodes);
-                        }
-
-                        // viewAsTree returns FileNode[]
-                        resolve(lll);
-                    }
-                );
+                return Promise.resolve(workspaces);
             }
-        });
+            return Promise.resolve(this.buildGroupNodes(undefined, hideEmpty));
+        }
+
+        if (element instanceof WorkspaceNode) {
+            return Promise.resolve(this.buildGroupNodes(element.controller, hideEmpty));
+        }
+
+        if (element instanceof GroupNode) {
+            return Promise.resolve(this.buildGroupChildren(element, viewAsList, hidePosition));
+        }
+
+        if (element instanceof FileNode) {
+            return Promise.resolve(this.buildBookmarkNodes(element.books ?? [], hidePosition));
+        }
+
+        return Promise.resolve([]);
     }
 
+    private buildGroupNodes(scopedController: Controller | undefined, hideEmpty: boolean): GroupNode[] {
+        const controllers = scopedController ? [scopedController] : this.controllers;
+        const activeGroupId = getActiveGroupId(scopedController?.workspaceFolder ?? this.controllers[0]?.workspaceFolder);
+        const groups = getGroups();
+        const nodes: GroupNode[] = [];
+        for (const group of groups) {
+            const count = countBookmarksInGroup(controllers, group.id);
+            if (hideEmpty && count === 0) {
+                continue;
+            }
+            const collapsibleState = count === 0
+                ? vscode.TreeItemCollapsibleState.None
+                : this.collapsibleState;
+            nodes.push(new GroupNode(group, controllers, count, group.id === activeGroupId, collapsibleState));
+        }
+        return nodes;
+    }
+
+    private buildGroupChildren(groupNode: GroupNode, viewAsList: boolean, hidePosition: boolean): SidebarNode[] {
+        const fileNodes: FileNode[] = [];
+        for (const controller of groupNode.controllers) {
+            for (const file of controller.files) {
+                const matching = file.bookmarks
+                    .filter(bkm => (bkm.groupId ?? DEFAULT_GROUP_ID) === groupNode.group.id);
+                if (matching.length === 0) {
+                    continue;
+                }
+                const previews = matching.map(bkm => bookmarkToPreview(file, bkm, controller));
+                const fileNode = new FileNode(
+                    path.basename(file.path),
+                    removeRelativePathFromFile(file.path),
+                    this.collapsibleState,
+                    BookmarkNodeKind.NODE_FILE,
+                    file,
+                    previews
+                );
+                fileNodes.push(fileNode);
+            }
+        }
+
+        if (viewAsList) {
+            const flat: BookmarkNode[] = [];
+            for (const fn of fileNodes) {
+                flat.push(...this.buildBookmarkNodes(fn.books ?? [], hidePosition));
+            }
+            return flat;
+        }
+
+        return fileNodes;
+    }
+
+    private buildBookmarkNodes(books: BookmarkPreview[], hidePosition: boolean): BookmarkNode[] {
+        return books.map(bbb => new BookmarkNode(
+            bbb.preview,
+            !hidePosition ? `(Ln ${bbb.line}, Col ${bbb.column})` : undefined,
+            vscode.TreeItemCollapsibleState.None,
+            BookmarkNodeKind.NODE_BOOKMARK,
+            null,
+            [],
+            {
+                command: "_bookmarks.jumpTo",
+                title: "",
+                arguments: [bbb.file, bbb.line, bbb.column, bbb.uri]
+            },
+            bbb.groupId
+        ));
+    }
+}
+
+function countBookmarksInGroup(controllers: Controller[], groupId: number): number {
+    let total = 0;
+    for (const controller of controllers) {
+        for (const file of controller.files) {
+            for (const bkm of file.bookmarks) {
+                if ((bkm.groupId ?? DEFAULT_GROUP_ID) === groupId) {
+                    total++;
+                }
+            }
+        }
+    }
+    return total;
+}
+
+function bookmarkToPreview(file: File, bkm: Bookmark, controller: Controller): BookmarkPreview {
+    const uri = getFileUri(file, controller.workspaceFolder);
+    const preview = bkm.label && bkm.label.length > 0
+        ? `✎ ${bkm.label}`
+        : `${codicons.bookmark ?? ""}`.trim() || file.path;
+    return {
+        file: file.path,
+        line: bkm.line + 1,
+        column: bkm.column + 1,
+        preview,
+        uri,
+        groupId: bkm.groupId ?? DEFAULT_GROUP_ID
+    };
 }
 
 function removeRelativePathFromFile(aPath: string): string {
@@ -381,7 +244,7 @@ function removeRelativePathFromFile(aPath: string): string {
 
 export class BookmarksExplorer {
 
-    private bookmarksExplorer: vscode.TreeView<BookmarkNode | WorkspaceNode | FileNode>;
+    private bookmarksExplorer: vscode.TreeView<SidebarNode>;
     private treeDataProvider: BookmarkProvider;
     private controllers: Controller[];
     private controllerListenerDisposables: vscode.Disposable[] = [];

--- a/src/sidebar/groupNode.ts
+++ b/src/sidebar/groupNode.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { l10n, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { Controller } from "../core/controller";
+import { BookmarkGroup } from "../core/groups";
+import { buildGroupGutterIcon } from "../decoration/decoration";
+import { BookmarkNodeKind } from "./nodes";
+
+export class GroupNode extends TreeItem {
+
+    public readonly kind = BookmarkNodeKind.NODE_GROUP;
+
+    constructor(
+        public readonly group: BookmarkGroup,
+        public readonly controllers: Controller[],
+        public readonly bookmarkCount: number,
+        public readonly isActive: boolean,
+        collapsibleState: TreeItemCollapsibleState
+    ) {
+        super(group.name, collapsibleState);
+
+        this.iconPath = buildGroupGutterIcon(group.color, group.borderColor);
+        this.contextValue = "BookmarkNodeGroup";
+
+        const parts: string[] = [];
+        if (bookmarkCount === 0) {
+            parts.push(l10n.t("(empty)"));
+        } else {
+            parts.push(`${bookmarkCount}`);
+        }
+        if (isActive) {
+            parts.push(l10n.t("(active)"));
+        }
+        this.description = parts.join(" ");
+    }
+}

--- a/src/sidebar/nodes.ts
+++ b/src/sidebar/nodes.ts
@@ -3,6 +3,6 @@
 *  Licensed under the GPLv3 License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-export enum BookmarkNodeKind { NODE_FILE, NODE_BOOKMARK, NODE_WORKSPACE_FOLDER }
+export enum BookmarkNodeKind { NODE_FILE, NODE_BOOKMARK, NODE_WORKSPACE_FOLDER, NODE_GROUP }
 
 export enum ViewAs { VIEW_AS_TREE, VIEW_AS_LIST }

--- a/src/statusBar/activeGroup.ts
+++ b/src/statusBar/activeGroup.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { Disposable, l10n, StatusBarAlignment, StatusBarItem, ThemeColor, window, workspace, WorkspaceFolder } from "vscode";
+import { Container } from "../core/container";
+import { getGroup, groupsConfigChanged } from "../core/groups";
+import { getActiveGroupId, onDidChangeActiveGroup } from "../core/groupState";
+
+export function registerActiveGroupStatusBar(getActiveWorkspaceFolder: () => WorkspaceFolder | undefined): StatusBarItem {
+    const item = window.createStatusBarItem(StatusBarAlignment.Left, 100);
+    item.command = "bookmarks.switchActiveGroup";
+    item.color = new ThemeColor("statusBarItem.foreground");
+
+    const render = () => {
+        const wsf = getActiveWorkspaceFolder();
+        const id = getActiveGroupId(wsf);
+        const group = getGroup(id);
+        item.text = `$(bookmark) ${group.name}`;
+        item.tooltip = l10n.t("Active Bookmark Group: {0}. Click to switch.", group.name);
+        item.show();
+    };
+
+    render();
+
+    const disposables: Disposable[] = [
+        item,
+        onDidChangeActiveGroup(() => render()),
+        window.onDidChangeActiveTextEditor(() => render()),
+        workspace.onDidChangeConfiguration(e => {
+            if (groupsConfigChanged(e)) {
+                render();
+            }
+        })
+    ];
+
+    Container.context.subscriptions.push(...disposables);
+    return item;
+}

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -6,7 +6,6 @@
 import os = require("os");
 import path = require("path");
 import { Uri, workspace, WorkspaceFolder } from "vscode";
-import { Bookmark } from "../core/bookmark";
 import { UNTITLED_SCHEME } from "../core/constants";
 import { File } from "../core/file";
 
@@ -106,18 +105,6 @@ export async function writeFileUri(uri: Uri, contents: string): Promise<void> {
 
 export async function deleteFileUri(uri: Uri): Promise<void> {
     await workspace.fs.delete(uri, { recursive: false, useTrash: false});
-}
-
-export function parsePosition(position: string): Bookmark | undefined {
-    const re = new RegExp(/\(Ln\s(\d+),\sCol\s(\d+)\)/);
-    const matches = re.exec(position);
-    if (matches) {
-        return {
-            line: parseInt(matches[ 1 ], 10),
-            column: parseInt(matches[ 2 ], 10)
-        };
-    }
-    return undefined;
 }
 
 export function getFileUri(file: File, workspaceFolder: WorkspaceFolder): Uri {

--- a/src/utils/reveal.ts
+++ b/src/utils/reveal.ts
@@ -4,8 +4,12 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { Selection, Uri, window, workspace } from "vscode";
-import { Bookmark } from "../core/bookmark";
 import { getRevealLocationConfig } from "./revealLocation";
+
+interface LineColumn {
+    line: number;
+    column: number;
+}
 
 export function revealLine(line: number, directJump?: boolean) {
     const newSe = new Selection(line, 0, line, 0);
@@ -24,13 +28,13 @@ export function revealPosition(line: number, column: number): void {
     }
 }
 
-export async function previewPositionInDocument(point: Bookmark, uri: Uri): Promise<void> {
+export async function previewPositionInDocument(point: LineColumn, uri: Uri): Promise<void> {
     const textDocument = await workspace.openTextDocument(uri);
     await window.showTextDocument(textDocument, { preserveFocus: true, preview: true });
     revealPosition(point.line - 1, point.column - 1);
 }
 
-export async function revealPositionInDocument(point: Bookmark, uri: Uri): Promise<void> {
+export async function revealPositionInDocument(point: LineColumn, uri: Uri): Promise<void> {
     const textDocument = await workspace.openTextDocument(uri);
     await window.showTextDocument(textDocument, undefined, false);
     revealPosition(point.line, point.column);


### PR DESCRIPTION
## Description

Add bookmark groups with per-group colors. Ten groups (0–9), each with an editable name and color. The existing  toggle still works and creates the bookmark in the per-workspace "active group". The active group is changed via the status bar item, which opens a quick-pick. (#778)

## Prerequisites Checklist
- [X] The code is up-to-date with the `master` branch
- [X] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [X] The code follows the repository's coding style
- [X] All changes are testable and have been manually tested

## Changes Made

- Added required `groupId: number` to `Bookmark`; old saves default to group 0.
- New settings: `bookmarks.groups` (10 entries, name + color) and `bookmarks.groups.hideEmpty`.
- New command: `bookmarks.switchActiveGroup` (quick-pick).
- Sidebar reorganized as `Group → File → Bookmark` (multi-root still gets a `Workspace` layer). List-mode toggle still flattens the File layer.
- Status bar item shows the active group; click opens the picker.
- `$group` and `$groupColor` available in `bookmarks.export.pattern`.
- Group 0's default color falls back to existing `gutterIconFillColor` / `gutterIconBorderColor` so upgraders see no visual change.

## Testing
- [X] Tested locally in VS Code Extension Development Host
- [ ] Tested on Windows
- [ ] Tested on macOS
- [X] Tested on Linux
- [ ] Tested on Remotes
- [X] Verified existing functionality still works (no regressions)

## Documentation
- [ ] Updated README.md  *(not yet — happy to follow up in a separate PR or this one if preferred)*

## Additional Notes

<img width="1264" height="1402" alt="Screenshot from 2026-05-21 02-35-28" src="https://github.com/user-attachments/assets/5d0a32eb-35b8-4e06-a93c-056f2e03762e" />
<img width="836" height="964" alt="Screenshot from 2026-05-21 02-35-07" src="https://github.com/user-attachments/assets/f0591bbd-e233-49f9-957c-2db01b8f300a" />